### PR TITLE
:sparkles: [Modal组件]提示类型modal增加icon配置

### DIFF
--- a/src/components/modal/demos/info.markdown
+++ b/src/components/modal/demos/info.markdown
@@ -45,6 +45,41 @@ export default class ModalDemo extends React.Component {
 		});
 	 };
 
+     openJSXModal = () => {
+        const dom = <p>hello world, this is a p element</p>;
+        Modal.info({
+            isShowIcon: false,
+            body: dom,
+            onCancel: () => {}
+        });
+     };
+
+    openNoIconModal = () => {
+        const dom = <p>hello world, there is no icon</p>;
+        Modal.info({
+            isShowIcon: false,
+            body: dom,
+            onCancel: () => {}
+        });
+    };
+
+    openDefineIconModal = () => {
+        Modal.info({
+            icon: 'flag-solid',
+            body: 'this is a defined icon',
+            onCancel: () => {}
+        });
+    };
+
+    openDefineIconStyleModal = () => {
+        Modal.info({
+            icon: 'flag-solid',
+            iconStyle: { color: "#aaa" },
+            body: 'this is a defined icon',
+            onCancel: () => {}
+        });
+    };
+
 	 render() {
 		 return (
 			 <div>
@@ -55,6 +90,16 @@ export default class ModalDemo extends React.Component {
 				 <Button type='normal' onClick={this.openErrorModal}>错误提示弹出框</Button>
 				 {blank}
 				 <Button type='normal' onClick={this.openWarningModal}>警告提示弹出框</Button>
+                 {blank}
+				 <Button type='normal' onClick={this.openJSXModal}>jsx语法提示</Button>
+                 {blank}
+				 <Button type='normal' onClick={this.openNoIconModal}>不显示icon</Button>
+                 {blank}
+                 <Button type='normal' onClick={this.openDefineIconModal}>自定义Icon</Button>
+                 {blank}
+                 <br/>
+                 <br/>
+                 <Button type='normal' onClick={this.openDefineIconStyleModal}>自定义Icon样式</Button>
 			 </div>
 		 );
 	 }

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -35,7 +35,7 @@ Modal.confirm = (props) => {
 	const config = {
 		...props,
 		type: 'confirm',
-		icon: 'question-circle-solid'
+		icon: props.icon || 'question-circle-solid'
 	};
 	return Prompt(config);
 };
@@ -45,7 +45,7 @@ Modal.info = (props) => {
 	const config = {
 		...props,
 		type: 'info',
-		icon: 'info-circle'
+		icon: props.icon || 'info-circle'
 	};
 	return Prompt(config);
 };
@@ -55,7 +55,7 @@ Modal.success = (props) => {
 	const config = {
 		...props,
 		type: 'success',
-		icon: 'check-circle-solid'
+		icon: props.icon || 'check-circle-solid'
 	};
 	return Prompt(config);
 };
@@ -65,7 +65,7 @@ Modal.error = (props) => {
 	const config = {
 		...props,
 		type: 'error',
-		icon: 'close-circle-solid'
+		icon: props.icon || 'close-circle-solid'
 	};
 	return Prompt(config);
 };
@@ -75,7 +75,7 @@ Modal.warning = (props) => {
 	const config = {
 		...props,
 		type: 'warning',
-		icon: 'warning-circle-solid'
+		icon: props.icon || 'warning-circle-solid'
 	};
 	return Prompt(config);
 };

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -30,8 +30,6 @@ subtitle: 弹出框
 
 
 #### method
- - 默认属性：title(提示信息标题), body(提示信息内容), onOk(确定按钮回调函数，仅confirm支持), onClose(取消按钮回调函数), isShowIcon(是否展示icon，默认为true展示)
- - confirm方法中的确定按钮回调函数支持返回promise，具体使用见示例demo。
 
 | 方法名 | 说明 | 用法 | 示例 |
 | --- | --- | --- | --- |
@@ -40,3 +38,13 @@ subtitle: 弹出框
 | error | 错误提示框 | Modal.error() | Modal.error({body: 'a error message'}) |
 | info | 信息提示框 | Modal.info() | Modal.info({body: 'a info message'}) |
 | warning | 警告提示框 | Modal.warning() | Modal.warning({body: 'a warning message'}) |
+
+ - 默认属性与方法：
+    - isShowIcon(是否显示提示信息前面的icon， 布尔类型，默认为true)
+    - icon(提示信息前面icon, 即icon组件中的type名称，字符串类型)
+    - iconStyle(提示信息前面icon的样式，对象类型)
+    - body(提示信息内容, 支持jsx语法直接传入dom节点) 
+    - onOk(确定按钮回调函数，仅confirm支持) 
+    - onClose(取消按钮回调函数)
+    
+ - **confirm方法中的确定按钮回调函数支持返回promise，具体使用见示例demo**

--- a/src/components/modal/prompt.js
+++ b/src/components/modal/prompt.js
@@ -13,8 +13,8 @@ const ENTER_KEY_CODE = 13;
 class Prompt extends React.Component{
 
 	static defaultProps = {
-		type: '',
 		isShowIcon: true,
+		type: '',
 		icon: '',
 		body: '',
 		onOk: () => {},
@@ -22,8 +22,8 @@ class Prompt extends React.Component{
 	};
 
 	static propTypes = {
-		type: PropTypes.string,
 		isShowIcon: PropTypes.bool,
+		type: PropTypes.string,
 		icon: PropTypes.string,
 		body: PropTypes.node,
 		onOk: PropTypes.func,
@@ -108,7 +108,8 @@ class Prompt extends React.Component{
 	};
 
 	render() {
-		const { type, icon, body, isShowIcon } = this.props;
+		const { isShowIcon, type, icon, body, iconStyle } = this.props;
+
 		const promptStyle = {
 			width: '200px'
 		};
@@ -122,7 +123,7 @@ class Prompt extends React.Component{
 				onOk={this.handleOk}>
 				<div>
 					<header className="info-area">
-						{ isShowIcon && <Icon type={icon} className={`icon-style ${type}-style` }/> }
+						{ isShowIcon && <Icon type={icon} className={ `icon-style ${type}-style` } style={iconStyle}/>}
 						<section className="more-info">{body}</section>
 					</header>
 				</div>
@@ -131,7 +132,7 @@ class Prompt extends React.Component{
 	}
 }
 
-function prompt({ type, icon, body, onOk, onCancel, isShowIcon }) {
+function prompt({ isShowIcon, type, icon, body, onOk, onCancel, iconStyle }) {
 	// 创建一个关联id
 	const id = `prompt${new Date().getTime()}`;
 	const ele = document.createElement('div');
@@ -142,8 +143,9 @@ function prompt({ type, icon, body, onOk, onCancel, isShowIcon }) {
 	ReactDOM.render(
 		<Prompt
 			id={id}
-			type={type}
 			isShowIcon={isShowIcon}
+			iconStyle={iconStyle}
+			type={type}
 			icon={icon}
 			body={body}
 			onOk={onOk}


### PR DESCRIPTION
1、增加isShowIcon属性，用于是否显示提示信息前面的icon， 布尔类型，默认为true；
2、增加icon属性，用于提示自定义信息前面icon, 即icon组件中的type名称，字符串类型；
3、增加iconStyle属性，用于自定义提示信息前面icon的样式，对象类型；
