### PR TITLE
:lipstick: [inputNumber] 修改默认高度和边框颜色，和其它表单组件保持一致

### DIFF
--- a/src/components/input-number/index.less
+++ b/src/components/input-number/index.less
@@ -3,7 +3,7 @@
 @input-number-prefix-cls: ~'@{prefix}-input-number';
 
 @border-color: #d9d9d9;
-@border-hover-color: #40a9ff;
+@border-hover-color: #aacbe1;
 
 @color: rgba(0, 0, 0, 0.65);
 @bg-color: #fff;
@@ -11,7 +11,7 @@
 @large-height: 40px;
 @large-fontSize: 16px;
 
-@default-height: 32px;
+@default-height: 30px;
 @default-fontSize: 14px;
 
 @small-height: 24px;
@@ -52,7 +52,6 @@
 	&-focused {
 		border-color: @border-hover-color;
 		outline: 0;
-		box-shadow: 0 0 0 2px rgba(24, 144, 255, .2);
 	}
 
 	&-disabled {


### PR DESCRIPTION
- inputNumber 组件默认高度 32px，其它表单组件默认高度 30px；
- inputNumber 组件鼠标 hover 和 focus 的颜色和其它表单组件不一致；
- inputNumber 组件，focus 的时候设置了 boxshadow（看起来也很不美观），其它表单组件没有设置