### PR TITLE
:sparkles: [TreeSelect] 完善下拉多选树

### DIFF
--- a/src/components/tree-select/demos/multiple.markdown
+++ b/src/components/tree-select/demos/multiple.markdown
@@ -12,12 +12,37 @@ import { TreeSelect } from 'cloud-react';
 export default class TreeSelectDemo extends React.Component {
 
     constructor(props) {
-        super(props);
-    }
+		super(props);
+		
+		this.state = {
+			selectedNodes: [{
+				id: 112,
+				name: '删除两个',
+				pId: 11
+			}],
+			confirmNodes:[{
+				id: 112,
+				name: '删除两个',
+				pId: 11
+			}]
+		}
+	}
 
     handleChange = (node, selectedNodes) => {
-        console.log(node, selectedNodes);
-    }
+		console.log(node, selectedNodes);
+		
+		this.setState({
+			selectedNodes
+		})
+	}
+	
+	onOk = (node, selectedNodes) => {
+		console.log(node, selectedNodes);
+		
+		this.setState({
+			confirmNodes: selectedNodes
+		})
+	}
 
 	render() {
 
@@ -185,13 +210,15 @@ export default class TreeSelectDemo extends React.Component {
 					style={{marginBottom: 20}}
 					placeholder="选择一个选项"
 					dataSource={treeData}
+					value={this.state.selectedNodes}
 					onChange={this.handleChange} />
 				<TreeSelect
 					multiple
 					hasConfirmButton
 					placeholder="选择一个选项"
 					dataSource={treeData}
-					onChange={this.handleChange} />
+					value={this.state.confirmNodes}
+					onOk={this.onOk} />
 			</div>
 		);
 	}

--- a/src/components/tree-select/index.js
+++ b/src/components/tree-select/index.js
@@ -37,7 +37,7 @@ class TreeSelect extends Component {
 		const { prevProps } = prevState;
 		const { value, dataSource } = props;
 		const { value: prevValue, dataSource: prevData } = prevProps;
-		if (value !== prevValue || !jeasy.equal(dataSource, prevData)) {
+		if (!jeasy.equal(value, prevValue) || !jeasy.equal(dataSource, prevData)) {
 			return {
 				value,
 				prevValue: value,
@@ -159,7 +159,7 @@ class TreeSelect extends Component {
 		if (!isClickSelect && open) {
 			const { onSelectClose, open: propOpen, hasConfirmButton } = this.props;
 			onSelectClose();
-			if (hasConfirmButton) this.onMultiOptionChange(prevValue);
+			if (hasConfirmButton) this.onMultiOptionChange({}, prevValue);
 			if (propOpen === null) this.setState({ open: false });
 		};
 	}
@@ -206,7 +206,8 @@ class TreeSelect extends Component {
 	onMultiOptionChange = (node, selectedNodes) => {
 		const { hasConfirmButton, onChange } = this.props;
 		this.setState({
-			value: selectedNodes
+			value: selectedNodes,
+			node
 		});
 		if (!hasConfirmButton) {
 			this.setState({
@@ -227,7 +228,8 @@ class TreeSelect extends Component {
 		});
 	}
 
-	handleOk = (node, selectedNodes) => {
+	handleOk = () => {
+		const { value: selectedNodes, node } = this.state;
 		this.setState({
 			prevValue: selectedNodes
 		});

--- a/src/components/tree-select/index.md
+++ b/src/components/tree-select/index.md
@@ -17,7 +17,7 @@ subtitle: 树下拉
 | open | 下拉菜单展开状态，当使用此属性时组件本身open行为失效 | boolean | - |
 | placeholder | 选择框默认文案 | string | - |
 | searchPlaceholder | 搜索框默认文案 | string | - |
-| searchable | 使下拉框带搜索 | boolean | false |
+| searchable | 使下拉框带搜索（多选暂不支持搜索） | boolean | false |
 | emptyRender | 数据为空时下拉框显示内容 | string\node | '暂时没有数据' |
 | defaultValue | 默认选中的项 | array | - |
 | value | 选中的项 | array | - |
@@ -25,7 +25,6 @@ subtitle: 树下拉
 | okBtnText | 多选时确认操作按钮文案| string | '确认' |
 | cancelBtnText | 多选时取消操作按钮文案 | string | '取消' |
 | className | 下拉菜单的 className 属性 | string | - |
-| zIndex | 下拉菜单的 zIndex | number | 1050 |
 | getPopupContainer | 下拉菜单渲染的父节点。如果发现下拉菜单被挡住，可以尝试修改定位父元素，如() => document.body | function(triggerNode) | triggerNode => triggerNode.parentElement |
 | containParentNode | 多选时结果是否包含各个父节点 | boolean | false |
 | onChange | 选中option变化时回调此函数 | function(node, selectedNodes) | - |

--- a/src/components/tree-select/tree.js
+++ b/src/components/tree-select/tree.js
@@ -23,7 +23,18 @@ class TreeContainer extends React.Component {
     }
 
     render() {
-        const { dataSource, multiple, searchable, hasConfirmButton, okBtnText, cancelBtnText, onOk, onCancel, ...otherProps } = this.props;
+        const {
+            dataSource,
+            multiple,
+            searchable,
+            value,
+            hasConfirmButton,
+            okBtnText,
+            cancelBtnText,
+            onOk,
+            onCancel,
+            ...otherProps
+        } = this.props;
         const classNames = cls(`${selector}-options`, {
             [`${selector}-options-confirm`]: hasConfirmButton
         });
@@ -31,9 +42,11 @@ class TreeContainer extends React.Component {
             <div className={classNames}>
                 <Tree
                     {...otherProps}
+                    showIcon={false}
+                    supportSearch={searchable}
+                    selectedValue={value}
                     onSelectedNode={this.selectNode}
                     treeData={dataSource}
-                    supportSearch={searchable}
                     supportCheckbox={multiple} />
                 {
                     hasConfirmButton &&
@@ -51,10 +64,10 @@ class TreeContainer extends React.Component {
 TreeContainer.propTypes = {
     dataSource: PropTypes.array,
     multiple: PropTypes.bool,
-	searchable: PropTypes.bool,
+    searchable: PropTypes.bool,
     hasConfirmButton: PropTypes.bool,
-	okBtnText: PropTypes.string,
-	cancelBtnText: PropTypes.string,
+    okBtnText: PropTypes.string,
+    cancelBtnText: PropTypes.string,
     onOk: PropTypes.func,
     onCancel: PropTypes.func,
 }
@@ -62,10 +75,10 @@ TreeContainer.propTypes = {
 TreeContainer.defaultProps = {
     dataSource: [],
     multiple: false,
-	searchable: false,
+    searchable: false,
     hasConfirmButton: false,
-	okBtnText: '',
-	cancelBtnText: '',
+    okBtnText: '',
+    cancelBtnText: '',
     onOk: () => {},
     onCancel: () => {},
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

https://github.com/ShuyunFF2E/cloud-react/issues/71

### 💡 需求背景和解决方案

1. 需要支持下拉多选
2. 下拉包裹树组件，组件内部交互以Tree为基准，onChange及带确认按钮的多选操作与Select组件基本一致，详见demo中的multiple.markdown

### 📝 更新日志怎么写？

支持下拉多选树


### ☑️ 请求合并前的自查清单

- [x] 文档已补充
- [x] 代码演示已提供
