### PR TITLE
[Select] 修改Select组件显示方式为内联块

### DIFF
--- a/src/components/select/index.less
+++ b/src/components/select/index.less
@@ -42,6 +42,7 @@
 }
 
 .@{select-prefix-cls} {
+	display: inline-block;
 	min-width: @min-width;
 	max-width: @max-width;
 	position: relative;
@@ -157,7 +158,6 @@
 }
 
 .@{select-prefix-cls}-open {
-
 	.@{select-prefix-cls}-wrapper {
 		border: @select-hover-border;
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 组件样式改进

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. Select组件显示为块元素布局，在表单项中使用大部分情况都需要去修改成内联块的方式

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. Select组件显示为块元素布局，在表单项中使用大部分情况都需要去修改成内联块的方式
2. 仅仅修改了`display: block` => `display: inline-block`

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
