### PR TITLE
[Modal] 去除弹框body容器设置的字体大小,自由的内容应继承项目设置的字体大小

### DIFF
--- a/src/components/modal/index.less
+++ b/src/components/modal/index.less
@@ -81,7 +81,7 @@
 	&-body {
 		max-height: calc(100vh - 200px);
 		min-height: 80px;
-		font-size: 14px;
+		// font-size: 14px;
 		color: @color-gray4;
 		padding: 20px;
 		overflow: auto;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 非定制化的Modal内容部分字体大小应该集成自项目全局所设置的字体大小

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
