### PR TITLE
[Modal]增加disabledOk属性，用于禁止点击确认按钮

### DIFF
--- a/src/components/modal/demos/style.markdown
+++ b/src/components/modal/demos/style.markdown
@@ -1,7 +1,7 @@
 ---
 order: 10
 title: 自定义样式
-desc: 使用style属性自定义modal组件样式
+desc: 使用style属性自定义modal组件样式，禁用确定按钮
 ---
 
 ```javascript
@@ -9,55 +9,59 @@ import React from 'react';
 import { Button, Modal, Message } from 'cloud-react';
 
 export default class ModalDemo extends React.Component {
-	 constructor(props) {
-		 super(props);
-		 this.state = {
-		 	visible: false
-		 };
-	 }
+	constructor(props) {
+		super(props);
+		this.state = {
+			visible: false
+		};
+	}
 
-	 // 打开弹出框
-	 openBasicModal = () => {
-	 	this.setState({
-	 		visible: true
-	 	});
-	 };
+	// 打开弹出框
+	openBasicModal = () => {
+		this.setState({
+			visible: true
+		});
+	};
 
-	 // 确认按钮回调函数
-	 handleOk = () => {
+	// 确认按钮回调函数
+	handleOk = () => {
 		this.setState({
 			visible: false
 		});
-	 };
+	};
 
-	 render() {
-	 	const modalStyle = {
-	 		width: '600px'
-	 	};
-        const bodyStyle = {
-	 		width: 'auto',
-            fontSize: '20px',
-	 		color: 'green',
-            height: '100px',
-            overflow: 'auto'
-	 	};
+	render() {
+		const modalStyle = {
+			width: '600px'
+		};
+		const bodyStyle = {
+			width: 'auto',
+			fontSize: '20px',
+			color: 'green',
+			height: '100px',
+			overflow: 'auto'
+		};
 
-		 return (
-			 <div>
-				 <Button type='primary' onClick={this.openBasicModal}>自定义样式弹出框</Button>
-				 <Modal
-				 	title='basic title'
-				 	bodyStyle={bodyStyle}
-                   className="test"
-                    modalStyle={modalStyle}
-				 	visible={this.state.visible}
-				 	onOk={this.handleOk}
-				 	onCancel={this.handleOk}
-				 	onClose={this.handleOk}>
-				 	this is a long content, this is a long content, this is a long content, this is a long content, this is a long content, this is a long content, this is a long content, this is a long content, this is a long content
-				 </Modal>
-			 </div>
-		 );
-	 }
+		return (
+			<div>
+				<Button type="primary" onClick={this.openBasicModal}>
+					自定义样式弹出框
+				</Button>
+				<Modal
+					title="basic title"
+					bodyStyle={bodyStyle}
+					className="test"
+					modalStyle={modalStyle}
+					disabledOk={true}
+					visible={this.state.visible}
+					onOk={this.handleOk}
+					onCancel={this.handleOk}
+					onClose={this.handleOk}>
+					this is a long content, this is a long content, this is a long content, this is a long content, this is a long content, this is a long
+					content, this is a long content, this is a long content, this is a long content
+				</Modal>
+			</div>
+		);
+	}
 }
 ```

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -3,16 +3,36 @@ import './index.less';
 import Notification from './modal';
 import Prompt from './prompt';
 
-class Modal extends Component{
+class Modal extends Component {
 	render() {
-		const { visible, modalStyle, bodyStyle, className, title, children, header, footer, hasFooter, onOk, onClose, onCancel, okText, cancelText, showMask, clickMaskCanClose, showConfirmLoading } = this.props;
-		return(
+		const {
+			visible,
+			modalStyle,
+			bodyStyle,
+			disabledOk,
+			className,
+			title,
+			children,
+			header,
+			footer,
+			hasFooter,
+			onOk,
+			onClose,
+			onCancel,
+			okText,
+			cancelText,
+			showMask,
+			clickMaskCanClose,
+			showConfirmLoading
+		} = this.props;
+		return (
 			<Notification
 				type="modal"
 				visible={visible}
 				title={title}
 				modalStyle={modalStyle}
 				bodyStyle={bodyStyle}
+				disabledOk={disabledOk}
 				className={className}
 				header={header}
 				footer={footer}
@@ -32,7 +52,7 @@ class Modal extends Component{
 }
 
 // confirm方法
-Modal.confirm = (props) => {
+Modal.confirm = props => {
 	const config = {
 		...props,
 		type: 'confirm',
@@ -42,7 +62,7 @@ Modal.confirm = (props) => {
 };
 
 // info方法
-Modal.info = (props) => {
+Modal.info = props => {
 	const config = {
 		...props,
 		type: 'info',
@@ -52,7 +72,7 @@ Modal.info = (props) => {
 };
 
 // success方法
-Modal.success = (props) => {
+Modal.success = props => {
 	const config = {
 		...props,
 		type: 'success',
@@ -62,7 +82,7 @@ Modal.success = (props) => {
 };
 
 // error方法
-Modal.error = (props) => {
+Modal.error = props => {
 	const config = {
 		...props,
 		type: 'error',
@@ -72,7 +92,7 @@ Modal.error = (props) => {
 };
 
 // warning方法
-Modal.warning = (props) => {
+Modal.warning = props => {
 	const config = {
 		...props,
 		type: 'warning',

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -18,6 +18,7 @@ subtitle: 弹出框
 | title              | 弹出框的标题                             | string              | title  |
 | modalStyle         | 设置弹出框样式                           | object              | -      |
 | bodyStyle          | 设置弹出框内容区域样式                   | object              | -      |
+| disabledOk         | 禁用确认按钮                             | boolean             | false  |
 | className          | 设置弹出框样式名称                       | string              | -      |
 | hasFooter          | 是否显示底部区域                         | boolean             | true   |
 | footer             | modal 底部内容区域                       | string 或 ReactNode | -      |

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -25,6 +25,7 @@ class Notification extends Component {
 		visible: false,
 		modalStyle: {},
 		bodyStyle: {},
+		disabledOk: false,
 		title: 'title',
 		children: '',
 		footer: '',
@@ -43,6 +44,7 @@ class Notification extends Component {
 		visible: PropTypes.bool,
 		modalStyle: PropTypes.object,
 		bodyStyle: PropTypes.object,
+		disabledOk: PropTypes.bool,
 		title: PropTypes.string,
 		children: PropTypes.node,
 		footer: PropTypes.node,
@@ -166,6 +168,7 @@ class Notification extends Component {
 			visible,
 			modalStyle,
 			bodyStyle,
+			disabledOk,
 			className,
 			id,
 			type,
@@ -229,6 +232,7 @@ class Notification extends Component {
 						type={type}
 						okText={okText}
 						cancelText={cancelText}
+						disabledOk={disabledOk}
 						showConfirmLoading={showConfirmLoading}
 						footer={footer}
 						hasFooter={hasFooter}
@@ -285,7 +289,7 @@ function ModalBody({ style, children }) {
 /**
  * @return {null}
  */
-function ModalFooter({ type, footer, okText, cancelText, hasFooter, showConfirmLoading, onCancel, onOk, onReset }) {
+function ModalFooter({ type, footer, okText, cancelText, hasFooter, showConfirmLoading, onCancel, onOk, onReset, disabledOk }) {
 	const ok = () => {
 		onReset();
 		onOk();
@@ -313,7 +317,7 @@ function ModalFooter({ type, footer, okText, cancelText, hasFooter, showConfirmL
 	}
 	return (
 		<footer className={footerClass}>
-			<Button type="primary" className={confirmClass} disabled={showConfirmLoading} onClick={ok}>
+			<Button type="primary" className={confirmClass} disabled={showConfirmLoading || disabledOk} onClick={ok}>
 				<ConfirmLoading showConfirmLoading={showConfirmLoading} />
 				{okText}
 			</Button>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在某些情况下，在进行modal内部操作时，不希望确定按钮能够点击，因此增加disabledOk属性，用于控制确定按钮能否点击；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、增加disabledOk属性，控制确定按钮能否点击，当设置了showConfirmLoading属性为true时，会优先使用showConfirmLoading；

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
