### PR TITLE
[Tag]修复点击事件获取不到event问题

### DIFF
--- a/src/components/tag/index.js
+++ b/src/components/tag/index.js
@@ -17,7 +17,6 @@ const typeEnum = {
 };
 
 export default class Tag extends Component {
-
 	static propTypes = {
 		type: PropTypes.oneOf([typeEnum.NONE, typeEnum.SUCCESS, typeEnum.WARNING, typeEnum.DEFAULT, typeEnum.DANGER]),
 		closable: PropTypes.bool,
@@ -37,19 +36,17 @@ export default class Tag extends Component {
 	};
 
 	get classes() {
-
 		const { checked, closable, type, disabled } = this.props;
 
 		return classnames(`${prefix}`, {
-			'closable': closable,
-			'checked': checked,
-			'disabled': disabled,
+			closable: closable,
+			checked: checked,
+			disabled: disabled,
 			[`${type}`]: !!type
 		});
 	}
 
 	handleRemove = event => {
-
 		const { onClose } = this.props;
 
 		if (onClose) {
@@ -58,33 +55,25 @@ export default class Tag extends Component {
 		}
 	};
 
-	handleClick = () => {
-
+	handleClick = evt => {
 		const { disabled, onClick } = this.props;
 
-		if(disabled) return;
+		if (disabled) return;
 
 		if (onClick) {
-			onClick();
+			onClick(evt);
 		}
 	};
 
 	render() {
-
 		const { closable, ...others } = this.props;
 
-		const props = omit(others, [
-			'type',
-			'checked',
-			'disabled',
-			'onClick',
-			'onClose'
-		]);
+		const props = omit(others, ['type', 'checked', 'disabled', 'onClick', 'onClose']);
 
 		return (
 			<span className={this.classes} onClick={this.handleClick} {...props}>
-				{ this.props.children }
-				{closable ? <Icon type="close" onClick={this.handleRemove} className="tag-close-icon"/> : null}
+				{this.props.children}
+				{closable ? <Icon type="close" onClick={this.handleRemove} className="tag-close-icon" /> : null}
 			</span>
 		);
 	}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. 需要在点击行为上进行阻止事件冒泡，但是获取不到`Event`对象

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 解决`onClick`事件获取不到`Event`对象问题

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
- 修复Tag组件点击行为获取不到`Event`对象bug


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
