### PR TITLE
[Form] 新增独立组件内部使用Field.init注册表单连接器

### DIFF
--- a/src/components/field/demos/basic-forms.markdown
+++ b/src/components/field/demos/basic-forms.markdown
@@ -38,23 +38,15 @@ export default class FormHorizontalDemo extends React.Component {
 
 		return (
 			<Form layout="horizontal" labelCol={{ span: 6 }} field={this.field}>
-				<Form.Item label="用户名">
-					<Input
-						placeholder="请输入用户名"
-						{...init('userName', {
-							rules: [{ required: true, message: '用户名不能为空' }, { len: 10 }]
-						})}
-					/>
+				<Form.Item label="用户名" help="使用了Form.Nexus组件，可以查看示例代码">
+					<User field={this.field} />
 				</Form.Item>
 
 				<Form.Item label="邮箱">
 					<Input
 						placeholder="请输入验证邮箱"
 						{...init('email', {
-							rules: [
-								{ required: true, message: '验证邮箱不能为空' },
-								{ pattern: /^\w+@[a-z]{2,10}\.[a-z]{2,8}$/, message: '邮箱格式不正确' }
-							]
+							rules: [{ required: true, message: '验证邮箱不能为空' }, { pattern: /^\w+@[a-z]{2,10}\.[a-z]{2,8}$/, message: '邮箱格式不正确' }]
 						})}
 					/>
 				</Form.Item>
@@ -141,5 +133,33 @@ export default class FormHorizontalDemo extends React.Component {
 			</Form>
 		);
 	}
+}
+
+function User({ field: { init } }) {
+	return (
+		<Form.Nexus>
+			<div style={{ display: 'inline-flex', alignItem: 'flex-start' }}>
+				<div>
+					<Input
+						style={{ width: 140, marginRight: 10 }}
+						placeholder="请输入名字"
+						{...init('firstName', {
+							rules: [{ required: true, message: '名字不能为空' }, { len: 10 }]
+						})}
+					/>
+				</div>
+
+				<div>
+					<Input
+						style={{ width: 100 }}
+						placeholder="请输入姓氏"
+						{...init('lastName', {
+							rules: [{ required: true, message: '姓氏不能为空' }, { len: 10 }]
+						})}
+					/>
+				</div>
+			</div>
+		</Form.Nexus>
+	);
 }
 ```

--- a/src/components/form/constants.js
+++ b/src/components/form/constants.js
@@ -1,3 +1,5 @@
+import { Children } from 'react';
+
 export const LAYOUT_TYPES = {
 	HORIZONTAL: 'horizontal',
 	VERTICAL: 'vertical',
@@ -7,4 +9,24 @@ export const LAYOUT_TYPES = {
 export const LABEL_ALIGN = {
 	LEFT: 'left',
 	RIGHT: 'right'
+};
+
+export const DATA_FIELD = 'data-field';
+
+export const findFieldsName = (children = []) => {
+	const result = [];
+
+	Children.toArray(children).forEach(child => {
+		const { props } = child;
+
+		if (props) {
+			if (props[DATA_FIELD]) {
+				result.push(props[DATA_FIELD]);
+			} else if (props.children && Children.count(props.children || [])) {
+				result.push(...findFieldsName(props.children));
+			}
+		}
+	});
+
+	return result;
 };

--- a/src/components/form/explain.js
+++ b/src/components/form/explain.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import classnames from 'classnames';
+import { prefixCls } from '@utils/config';
+
+export default function Explain({ children, className }) {
+	return children && <div className={classnames(`${prefixCls}-form-item-explain`, className)}>{children}</div>;
+}

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { prefixCls } from '@utils/config';
 
 import FormItem from './form-item';
+import Nexus from './nexus';
 import FormContext from './context';
 import { LAYOUT_TYPES, LABEL_ALIGN } from './constants';
 
@@ -40,6 +41,8 @@ export default class Form extends Component {
 	};
 
 	static Item = FormItem;
+
+	static Nexus = Nexus;
 
 	render() {
 		const { children, colon, field, layout, labelCol, wrapperCol, labelAlign, className, ...others } = this.props;

--- a/src/components/form/index.less
+++ b/src/components/form/index.less
@@ -114,7 +114,7 @@
 
 		// 表单校验样式
 		.has-error {
-			.select-wrapper,
+			.@{prefix}-select-wrapper,
 			.@{prefix}-input-number,
 			.@{prefix}-input-textarea,
 			.@{prefix}-input {
@@ -123,7 +123,7 @@
 		}
 	}
 
-	.loop(@counter) when (@counter <= 24){
+	.loop(@counter) when (@counter <= 24) {
 		.col-@{counter} {
 			@ret: 100 / 24 * @counter;
 			width: ~'@{ret}%';

--- a/src/components/form/index.md
+++ b/src/components/form/index.md
@@ -5,33 +5,91 @@ subtitle: 表单
 ---
 
 ### 何时使用
+
 当你需要集体收集信息或者对控件做校验的时候。
 
 ### API
 
 ### Form
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| field | `new Field(this)`之后的实例，用到表单校验则时此项必填 | object | - |
-| layout | 表单展示方向，可设置`horizontal` `vertical` `inline` | string | `vertical` |
-| labelAlign | 标签的对齐位置，可设置`left` `right` | string | `right` |
-| labelCol | `label` 标签布局，设置 `span` `offset` 值，如 `{span: 3, offset: 12}` | string | - |
-| wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 `labelCol` | string | - |
-| onSubmit | form内有`htmlType="submit"`的元素的时候会触发 | Function(evt:Event) | - |
-| colon | 配合`label`属性使用，表示是否显示`label`后面的冒号 | boolean | `true` |
-| className | Form 的 className 属性 | string | - |
+| 属性       | 说明                                                                  | 类型                | 默认值     |
+| ---------- | --------------------------------------------------------------------- | ------------------- | ---------- |
+| field      | `new Field(this)`之后的实例，用到表单校验则时此项必填                 | object              | -          |
+| layout     | 表单展示方向，可设置`horizontal` `vertical` `inline`                  | string              | `vertical` |
+| labelAlign | 标签的对齐位置，可设置`left` `right`                                  | string              | `right`    |
+| labelCol   | `label` 标签布局，设置 `span` `offset` 值，如 `{span: 3, offset: 12}` | string              | -          |
+| wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 `labelCol`           | string              | -          |
+| onSubmit   | form 内有`htmlType="submit"`的元素的时候会触发                        | Function(evt:Event) | -          |
+| colon      | 配合`label`属性使用，表示是否显示`label`后面的冒号                    | boolean             | `true`     |
+| className  | Form 的 className 属性                                                | string              | -          |
 
-如果Form和Form.Item相同的属性，Form.Item的优先级更高，如果Form上设置了就不用每一个Form.Item上都进行设置，更加方便
+如果 Form 和 Form.Item 相同的属性，Form.Item 的优先级更高，如果 Form 上设置了就不用每一个 Form.Item 上都进行设置，更加方便
 
 ### Form.Item
 
-| 属性 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| label | `label` 标签的文本 | string|ReactNode | - |
-| help | 提示信息，如不设置，则会根据校验规则自动生成 | string|ReactNode | - |
-| htmlFor | 设置子元素 `label` `htmlFor` 属性 | string | - |
-| required | 是否必填，如不设置，则会根据校验规则自动生成 | boolean | `false` |
-| labelCol | `label` 标签布局，设置 `span` `offset` 值，如 `{span: 3, offset: 12}` | string | - |
-| wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 `labelCol` | string | - |
-| className | Form.Item 的 className 属性 | string | - |
+| 属性       | 说明                                                                  | 类型    | 默认值    |
+| ---------- | --------------------------------------------------------------------- | ------- | --------- |
+| label      | `label` 标签的文本                                                    | string  | ReactNode | - |
+| help       | 提示信息，如不设置，则会根据校验规则自动生成                          | string  | ReactNode | - |
+| htmlFor    | 设置子元素 `label` `htmlFor` 属性                                     | string  | -         |
+| required   | 是否必填，如不设置，则会根据校验规则自动生成                          | boolean | `false`   |
+| labelCol   | `label` 标签布局，设置 `span` `offset` 值，如 `{span: 3, offset: 12}` | string  | -         |
+| wrapperCol | 需要为输入控件设置布局样式时，使用该属性，用法同 `labelCol`           | string  | -         |
+| className  | Form.Item 的 className 属性                                           | string  | -         |
+
+### Form.Nexus
+
+当你的表单校验场景比较复杂或者将`Form.Item`内容抽离出去的时候就需要使用到`Form.Nexus`组件跟`Form`建立关系了，因为程序无法窥视到自定义组件的内容，添加了该组件并不会在 HTML 结构上破坏你预想的结构
+
+```jsx
+import { Form, Field, Input } from 'cloud-react';
+
+// 简单场景
+function FormA() {
+	const field = Field.useField();
+
+	return (
+		<Form field={field}>
+			<Form.Item>
+				<Input
+					{...field.init('name', {
+						rules: [{ required: true, message: '用户名必须填写' }]
+					})}
+				/>
+			</Form.Item>
+		</Form>
+	);
+}
+
+// 复杂场景，需要使用Nexus组件
+function FormB() {
+	B;
+	const field = Field.useField();
+
+	return (
+		<Form field={field}>
+			<Form.Item>
+				<UseNexus field={field} />
+			</Form.Item>
+		</Form>
+	);
+}
+
+function UseNexus() {
+	return (
+		<Form.Nexus>
+			<Input
+				{...field.init('firstName', {
+					rules: [{ required: true, message: '名字必须填写' }]
+				})}
+			/>
+
+			<Input
+				{...field.init('lastName', {
+					rules: [{ required: true, message: '姓氏必须填写' }]
+				})}
+			/>
+		</Form.Nexus>
+	);
+}
+```

--- a/src/components/form/nexus.js
+++ b/src/components/form/nexus.js
@@ -1,0 +1,103 @@
+import React, { Component, Children, cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import FormContext from './context';
+import Explain from './explain';
+
+import { DATA_FIELD, findFieldsName } from './constants';
+
+const noop = () => {};
+
+export default class FormB extends Component {
+	static contextType = FormContext;
+
+	static propTypes = {
+		children: PropTypes.any
+	};
+
+	static defaultProps = {
+		children: null
+	};
+
+	componentWillUnmount() {
+		const { field, dataFields } = this;
+
+		// 如果设置了校验规则，则重置并删除
+		if (field && field.remove && dataFields && dataFields.length) {
+			field.remove(dataFields);
+		}
+	}
+
+	get field() {
+		return this.context.field;
+	}
+
+	get fieldsMeta() {
+		if (this.field && this.field.fieldsMeta) {
+			return this.field.fieldsMeta;
+		}
+		return null;
+	}
+
+	get dataFields() {
+		const {
+			field,
+			props: { children }
+		} = this;
+		const fieldsName = findFieldsName(children);
+
+		if (field && field.fieldsMeta && fieldsName.length) {
+			return fieldsName;
+		}
+
+		return null;
+	}
+
+	renderChildren(children) {
+		if (['object', 'string', 'array'].indexOf(typeof children) === -1) {
+			return children;
+		}
+
+		return Children.map(children, (child, key) => {
+			if (!child) return null;
+
+			const { props } = child;
+
+			if (!props) return child;
+
+			if (props && props[DATA_FIELD]) {
+				const { getState = noop, getError = noop } = this.field || {};
+
+				const state = getState.call(this.field, props[DATA_FIELD]);
+				const error = getError.call(this.field, props[DATA_FIELD]);
+
+				return (
+					<div
+						key={key.toString()}
+						className={classnames('contents', {
+							'has-error': state === 'error',
+							'has-success': state === 'success'
+						})}>
+						{cloneElement(child, child.props)}
+						{error ? <Explain className="error">{error}</Explain> : null}
+					</div>
+				);
+			}
+
+			let items = props.children;
+
+			if (props.children && Children.count(props.children) && !props[DATA_FIELD]) {
+				items = this.renderChildren(props.children);
+			}
+
+			return cloneElement(child, { key, ...child.props, children: items });
+		});
+	}
+
+	render() {
+		const { children } = this.props;
+
+		return this.renderChildren(children);
+	}
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. Form.Item组件内容如果是抽离组件的话，Field注册的校验就没法触发页面的渲染，因为Form.Item无法窥视被抽离组件内部存在的内容

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 解决复杂表单场景下嵌套独立组件内部存在表单校验行为时无法处理错误等相关提示问题

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1. 修复复杂表单场景下嵌套独立组件内部存在表单校验行为时无法处理错误等相关提示问题


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
