### PR TITLE
[Tree]修复选中节点后切换回显数据选中节点状态未变化问题

### DIFF
--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -89,9 +89,10 @@ class Tree extends Component {
 			return {
 				selectedValue: nextProps.selectedValue,
 				prevProps: nextProps,
-				treeData: store.initData(nextProps.treeData, prevState.maxLevel, nextProps.selectedValue, prevState.isUnfold)
+				treeData: store.initData(nextProps.treeData, prevProps.maxLevel, nextProps.selectedValue, prevProps.isUnfold)
 			};
 		}
+
 		return null;
 	}
 

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -23,7 +23,7 @@ class Store {
 		// 单选则直接选中回显值，多选则默认第一个
 		this.activeNode = selectedValue && selectedValue[0];
 		// 处理已选中的节点，treeData中存在selectedValue中的值则选中
-		const cloneData = jEasy.clone(treeData);
+		const cloneData = this.onResetData(jEasy.clone(treeData));
 
 		// 递归向上查找选择
 		const upFind = currentNode => {
@@ -111,6 +111,37 @@ class Store {
 			});
 		}
 		return cloneData;
+	};
+
+	/**
+	 * 重置选中情况
+	 * @param data
+	 * @returns {{length}|*}
+	 */
+	onResetData = data => {
+		const format = item => {
+			// eslint-disable-next-line no-param-reassign
+			item.indeterminate = false;
+			// eslint-disable-next-line no-param-reassign
+			item.checked = false;
+			if (item.children && item.children.length) {
+				item.children.forEach(i => {
+					// eslint-disable-next-line no-param-reassign
+					i.indeterminate = false;
+					// eslint-disable-next-line no-param-reassign
+					i.checked = false;
+					format(i);
+				});
+			}
+		};
+
+		if (data.length) {
+			data.map(item => {
+				return format(item);
+			});
+		}
+
+		return data;
 	};
 
 	/**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1、设置了isUnfold属性，但是一直都处于闭合状态，bug，取值错误，导致出现undefined；
2、选中过节点后，再切换回显数据，选中项状态未改变，节点选中状态没有清除，已统一初始化数据清除选中状态；

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、修复选中数据后回显数据变化但是选中节点状态未变化bug；
2、修复设置isUnfold为true后选择节点但又闭合的bug；

### ☑️ 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
