### PR TITLE
[Tree]默认不展示节点前面的图标, 兼容无数据状态

### DIFF
--- a/src/components/tree/demos/showIcon.markdown
+++ b/src/components/tree/demos/showIcon.markdown
@@ -1,7 +1,7 @@
 ---
 order: 6
 title: 是否显示节点icon
-desc:  配置是否显示节点icon
+desc: 配置是否显示节点icon
 ---
 
 ```javascript
@@ -9,13 +9,12 @@ import React from 'react';
 import { Tree } from 'cloud-react';
 
 export default class TreeDemo extends React.Component {
-
 	constructor(props) {
 		super(props);
 
 		this.state = {
-			showIcon: false
-		}
+			showIcon: true
+		};
 	}
 
 	selectedNode = (node, selectedList) => {
@@ -26,73 +25,76 @@ export default class TreeDemo extends React.Component {
 	};
 
 	render() {
-        const treeData = [{
-            id: 1,
-            name: '所有',
-            pId: null,
-            children: [
-                {
-                    id: 11,
-                    name: '禁止新增节点',
-                    pId: 1,
-                    disableAdd: true,
-                    children: [
-                        {
-                            id: 111,
-                            name: '22323',
-                            pId: 11,
-                            categoryType: 0
-                        }
-                    ]
-                }, {
-                    id: 12,
-                    name: '禁止删除节点',
-                    pId: 1,
-                    disableRemove: true,
-                    children: [
-                        {
-                            id: 121,
-                            name: '禁止重命名节点',
-                            pId: 12,
-                            disableRename: true,
-                            children: [
-                                {
-                                    id: 1211,
-                                    name: '2345',
-                                    pId: 121
-                                }
-                            ]
-                        }, {
-                            id: 122,
-                            name: 'lerous',
-                            pId: 12
-                        }, {
-                            id: 123,
-                            name: 'baukh321',
-                            pId: 12
-                        }, {
-                            id: 124,
-                            name: 'bauh789',
-                            pId: 12
-                        }, {
-                            id: 125,
-                            name: 'baukh',
-                            pId: 12
-                        }
-                    ]
-                }, {
-                    id: 13,
-                    name: '未分类',
-                    pId: 1
-                }
-            ]
-        }];
-		return (
-			<Tree
-				treeData={treeData}
-				showIcon={this.state.showIcon}
-				onSelectedNode={this.selectedNode}/>
-		);
+		const treeData = [
+			{
+				id: 1,
+				name: '所有',
+				pId: null,
+				children: [
+					{
+						id: 11,
+						name: '禁止新增节点',
+						pId: 1,
+						disableAdd: true,
+						children: [
+							{
+								id: 111,
+								name: '22323',
+								pId: 11,
+								categoryType: 0
+							}
+						]
+					},
+					{
+						id: 12,
+						name: '禁止删除节点',
+						pId: 1,
+						disableRemove: true,
+						children: [
+							{
+								id: 121,
+								name: '禁止重命名节点',
+								pId: 12,
+								disableRename: true,
+								children: [
+									{
+										id: 1211,
+										name: '2345',
+										pId: 121
+									}
+								]
+							},
+							{
+								id: 122,
+								name: 'lerous',
+								pId: 12
+							},
+							{
+								id: 123,
+								name: 'baukh321',
+								pId: 12
+							},
+							{
+								id: 124,
+								name: 'bauh789',
+								pId: 12
+							},
+							{
+								id: 125,
+								name: 'baukh',
+								pId: 12
+							}
+						]
+					},
+					{
+						id: 13,
+						name: '未分类',
+						pId: 1
+					}
+				]
+			}
+		];
+		return <Tree treeData={treeData} showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
 	}
 }
 ```

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -23,7 +23,7 @@ class Tree extends Component {
 		nodeNameMaxLength: '',
 		maxLevel: 0,
 		isUnfold: false,
-		showIcon: true,
+		showIcon: false,
 		openIconType: 'folder-solid-open',
 		closeIconType: 'folder-solid',
 		iconColor: '#999',
@@ -371,9 +371,11 @@ class Tree extends Component {
 						visible={visibleMenu}
 					/>
 
-					{treeData[0].children.length > 0 && <TreeList prefixCls={selector} nodeNameMaxLength={nodeNameMaxLength} data={treeData} />}
+					{treeData && treeData.length > 0 && treeData[0].children && treeData[0].children.length > 0 && (
+						<TreeList prefixCls={selector} nodeNameMaxLength={nodeNameMaxLength} data={treeData} />
+					)}
 
-					{!treeData[0].children.length && <p>暂无搜索结果</p>}
+					{(!treeData || !treeData.length || !treeData[0].children || !treeData[0].children.length) && <p>暂无结果</p>}
 				</div>
 			</TreeContext.Provider>
 		);

--- a/src/components/tree/index.md
+++ b/src/components/tree/index.md
@@ -23,7 +23,7 @@ subtitle: 树
 | supportCheckbox          | 是否支持多选，false 为单选，true 为多选                              | Boolean  | false             |
 | supportMenu              | 是否支持右键菜单                                                     | Boolean  | true              |
 | isUnfold                 | 是否展开存在子节点的节点，默认不展开（根节点一直展开）               | Boolean  | false             |
-| showIcon                 | 是否显示节点前面的 icon                                              | Boolean  | true              |
+| showIcon                 | 是否显示节点前面的 icon                                              | Boolean  | false              |
 | openIconType             | 节点前面的展开 icon 类型，可在 icon 组件中查看相关类型               | String   | folder-solid-open |
 | closeIconType            | 节点前面的关闭 icon 类型，可在 icon 组件中查看相关类型               | String   | folder-solid      |
 | iconColor                | 节点前面的 icon 颜色                                                 | String   | #999              |

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -20,6 +20,10 @@ class Store {
 	 * @returns {*}
 	 */
 	initData = (treeData, maxLevel, selectedValue, isUnfold) => {
+		// 数据不存在或无数据使时
+		if (!treeData || !treeData.length) {
+			return [];
+		}
 		// 单选则直接选中回显值，多选则默认第一个
 		this.activeNode = selectedValue && selectedValue[0];
 		// 处理已选中的节点，treeData中存在selectedValue中的值则选中


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、根据UI建议，默认不展示节点前面的图标；
2、当传入的treeData为空或不存在时，组件报错；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、设置showIcon的默认值为false，默认不展示节点前面的小图标；
2、兼容treeData为空或不存在情况时，显示无结果提示；


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
