### PR TITLE
:bug:[Tree]修复节点id或pId为0的时选择或回显状态错乱问题

### DIFF
--- a/src/components/tree/demos/changeSelectedValue.markdown
+++ b/src/components/tree/demos/changeSelectedValue.markdown
@@ -35,15 +35,15 @@ export default class TreeDemo extends React.Component {
 		const randomSelected = [
 			{
 				id: 11,
-				pId: 1
+				pId: 0
 			},
 			{
 				id: 12,
-				pId: 1
+				pId: 0
 			},
 			{
 				id: 13,
-				pId: 1
+				pId: 0
 			},
 			{
 				id: 121,
@@ -96,14 +96,14 @@ export default class TreeDemo extends React.Component {
 	render() {
 		const treeData = [
 			{
-				id: 1,
+				id: 0,
 				name: '根节点',
 				pId: null,
 				children: [
 					{
 						id: 11,
 						name: '一级节点1',
-						pId: 1,
+						pId: 0,
 						disableAdd: true,
 						children: [
 							{
@@ -117,7 +117,7 @@ export default class TreeDemo extends React.Component {
 					{
 						id: 12,
 						name: '一级节点2',
-						pId: 1,
+						pId: 0,
 						disableRemove: true,
 						children: [
 							{
@@ -188,7 +188,7 @@ export default class TreeDemo extends React.Component {
 					{
 						id: 13,
 						name: '节点3',
-						pId: 1
+						pId: 0
 					}
 				]
 			}

--- a/src/components/tree/index.md
+++ b/src/components/tree/index.md
@@ -23,7 +23,7 @@ subtitle: 树
 | supportCheckbox          | 是否支持多选，false 为单选，true 为多选                              | Boolean  | false             |
 | supportMenu              | 是否支持右键菜单                                                     | Boolean  | true              |
 | isUnfold                 | 是否展开存在子节点的节点，默认不展开（根节点一直展开）               | Boolean  | false             |
-| showIcon                 | 是否显示节点前面的 icon                                              | Boolean  | false              |
+| showIcon                 | 是否显示节点前面的 icon                                              | Boolean  | false             |
 | openIconType             | 节点前面的展开 icon 类型，可在 icon 组件中查看相关类型               | String   | folder-solid-open |
 | closeIconType            | 节点前面的关闭 icon 类型，可在 icon 组件中查看相关类型               | String   | folder-solid      |
 | iconColor                | 节点前面的 icon 颜色                                                 | String   | #999              |
@@ -42,7 +42,7 @@ subtitle: 树
 -   disableRename: 布尔类型，设置为 true 则表示不可重命名；
 -   disableRemove: 布尔类型，设置为 true 则表示不可删除；
 -   disableSelected: 布尔类型，设置为 true 则表示不可选择，只是不可选择该节点，若有子节点，其子节点仍可以选择；
--   pId 与 parentId：父节点 id，使用时可写成 parentId 也可写成 pId
+-   pId：父节点 id
 
 ### 数据格式：treeData 属性值
 

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -70,15 +70,18 @@ class Store {
 			// 增加是否展开标志
 			tmp.isUnfold = isUnfold;
 
-			// 根节点默认展开
-			if (!+node.pId) {
+			// 寻找父节点
+			const pNode = this.findNodeById(cloneData, tmp.pId);
+			// 无父节点则为根节点，默认展开
+			if (!pNode) {
 				tmp.isUnfold = true;
 			}
 
 			// 存在已选中节点，则根节点半选
-			if (selectedValue && selectedValue.length && !node.pId) {
+			if (selectedValue && selectedValue.length && !pNode) {
 				tmp.indeterminate = true;
 			}
+
 			if (!children) {
 				tmp.children = [];
 			}
@@ -180,7 +183,7 @@ class Store {
 	 * @returns {*}
 	 */
 	selectedForCheckbox(data, node) {
-		const { checked, children, pId, parentId } = node;
+		const { checked, children, pId } = node;
 		// eslint-disable-next-line no-param-reassign
 		node.indeterminate = false;
 		// 变更自身节点选中状态
@@ -243,13 +246,13 @@ class Store {
 				parentNode.indeterminate = true;
 			}
 
-			if (parentNode.pId || parentNode.parentId) {
-				changeParent(parentNode.pId || parentNode.parentId);
+			if (parentNode.pId || parentNode.pId === 0) {
+				changeParent(parentNode.pId);
 			}
 		};
 
 		changeChildren(children || []);
-		changeParent(pId || parentId);
+		changeParent(pId);
 		return data;
 	}
 
@@ -367,7 +370,7 @@ class Store {
 	 * @returns {*}
 	 */
 	removeChildNode(data, node) {
-		const parentNode = this.findNodeById(data, node.pId || node.parentId);
+		const parentNode = this.findNodeById(data, node.pId);
 
 		// 存在子节点则不可删除
 		if (!parentNode || node.children.length) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
某些情况下，节点的id或者pId为0，导致在组件内部进行判断时出现判断错误情况，进而致使节点选择或回显等功能收到影响；

增加判断是否为0的判断条件进行兼容；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、清除使用parentId的方式设置父节点id；
2、兼容节点id或pId为0情况；

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
