### PR TITLE
[Tree] 调整icon大小，增加禁止用户选择样式，不设置右键菜单时使用浏览器菜单，只监听selectedValue…

### DIFF
--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -85,7 +85,7 @@ class Tree extends Component {
 	static getDerivedStateFromProps(nextProps, prevState) {
 		const { prevProps } = prevState;
 
-		if (prevProps !== nextProps) {
+		if (prevProps.selectedValue !== nextProps.selectedValue) {
 			return {
 				selectedValue: nextProps.selectedValue,
 				prevProps: nextProps,

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -16,6 +16,10 @@
 
 .@{selector} {
 	position: relative;
+	user-select: none;
+	.@{prefix}-icon {
+		font-size: 14px;
+	}
 
 	ul {
 		margin: 0;

--- a/src/components/tree/node.js
+++ b/src/components/tree/node.js
@@ -22,6 +22,10 @@ class Node extends Component {
 
 	// 打开右键菜单
 	onHandleContextMenu = (e, node, options) => {
+		// 不使用右键菜单则使用浏览器默认右键菜单
+		if (!this.context.supportMenu) {
+			return;
+		}
 		e.preventDefault();
 		const menuStyle = {
 			left: `${e.clientX}px`,


### PR DESCRIPTION
…状态改变

<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、UI反馈样式问题，以及在快速点击展开折叠按钮时可能会存在选中文本的情况；
2、不设置右键菜单时默认无法使用浏览器默认菜单，导致菜单功能缺失；
3、组件使用场景中外部状态变化时，重新渲染tree，导致组件状态初始化；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、调整icon大小为14px；
2、在未设置开启右键菜单时，默认使用浏览器菜单；
3、增加不允许选择节点文本；
4、修复重新渲染tree时触发初始化操作bug，调整为只监听selectedValue字段变化后才重新初始化；

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
