### PR TITLE
[Modal]新增getPopupContainer方法允许用户自己指定节点渲染父级

### DIFF
--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,53 +1,32 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+
 import './index.less';
 import Notification from './modal';
 import Prompt from './prompt';
 
 class Modal extends Component {
+	static propTypes = {
+		getPopupContainer: PropTypes.func,
+		children: PropTypes.any
+	};
+
+	static defaultProps = {
+		getPopupContainer: () => document.body,
+		children: null
+	};
+
 	render() {
-		const {
-			visible,
-			modalStyle,
-			bodyStyle,
-			disabledOk,
-			className,
-			title,
-			children,
-			header,
-			footer,
-			hasFooter,
-			onOk,
-			onClose,
-			onCancel,
-			okText,
-			cancelText,
-			showMask,
-			clickMaskCanClose,
-			showConfirmLoading
-		} = this.props;
-		return (
-			<Notification
-				type="modal"
-				visible={visible}
-				title={title}
-				modalStyle={modalStyle}
-				bodyStyle={bodyStyle}
-				disabledOk={disabledOk}
-				className={className}
-				header={header}
-				footer={footer}
-				hasFooter={hasFooter}
-				showMask={showMask}
-				okText={okText}
-				cancelText={cancelText}
-				clickMaskCanClose={clickMaskCanClose}
-				showConfirmLoading={showConfirmLoading}
-				onOk={onOk}
-				onCancel={onCancel}
-				onClose={onClose}>
+		const { getPopupContainer, children, ...props } = this.props;
+
+		const Child = (
+			<Notification type="modal" {...props}>
 				{children}
 			</Notification>
 		);
+
+		return ReactDOM.createPortal(Child, getPopupContainer());
 	}
 }
 

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -12,24 +12,25 @@ subtitle: 弹出框
 
 ### Modal
 
-| 属性               | 说明                                     | 类型                | 默认值 |
-| ------------------ | ---------------------------------------- | ------------------- | ------ |
-| visible            | 是否显示 modal 弹出框                    | boolean             | false  |
-| title              | 弹出框的标题                             | string              | title  |
-| modalStyle         | 设置弹出框样式                           | object              | -      |
-| bodyStyle          | 设置弹出框内容区域样式                   | object              | -      |
-| disabledOk         | 禁用确认按钮                             | boolean             | false  |
-| className          | 设置弹出框样式名称                       | string              | -      |
-| hasFooter          | 是否显示底部区域                         | boolean             | true   |
-| footer             | modal 底部内容区域                       | string 或 ReactNode | -      |
-| onClose            | 点击右上角关闭按钮时触发的回调           | function            | -      |
-| onOk               | 点击确定按钮时触发的回调                 | function            | -      |
-| onCancel           | 点击取消按钮时触发的回调                 | function            | -      |
-| okText             | 确定按钮自定义文本                       | string              | 确定   |
-| cancelText         | 取消按钮自定义文本                       | string              | 取消   |
-| showMask           | 是否显示遮罩层                           | boolean             | true   |
-| clickMaskCanClose  | 点击遮罩层是否关闭, showMask 必须为 true | boolean             | true   |
-| showConfirmLoading | 点击确定是否显示 loading，用于异步关闭   | boolean             | false  |
+| 属性               | 说明                                     | 类型                | 默认值              |
+| ------------------ | ---------------------------------------- | ------------------- | ------------------- |
+| visible            | 是否显示 modal 弹出框                    | boolean             | false               |
+| title              | 弹出框的标题                             | string              | title               |
+| modalStyle         | 设置弹出框样式                           | object              | -                   |
+| bodyStyle          | 设置弹出框内容区域样式                   | object              | -                   |
+| disabledOk         | 禁用确认按钮                             | boolean             | false               |
+| className          | 设置弹出框样式名称                       | string              | -                   |
+| hasFooter          | 是否显示底部区域                         | boolean             | true                |
+| footer             | modal 底部内容区域                       | string 或 ReactNode | -                   |
+| onClose            | 点击右上角关闭按钮时触发的回调           | function            | -                   |
+| onOk               | 点击确定按钮时触发的回调                 | function            | -                   |
+| onCancel           | 点击取消按钮时触发的回调                 | function            | -                   |
+| okText             | 确定按钮自定义文本                       | string              | 确定                |
+| cancelText         | 取消按钮自定义文本                       | string              | 取消                |
+| showMask           | 是否显示遮罩层                           | boolean             | true                |
+| clickMaskCanClose  | 点击遮罩层是否关闭, showMask 必须为 true | boolean             | true                |
+| showConfirmLoading | 点击确定是否显示 loading，用于异步关闭   | boolean             | false               |
+| getPopupContainer  | Modal 渲染的父节点                       | function            | () => document.body |
 
 ### Modal.method()
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/ShuyunFF2E/cloud-react/issues/274

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 修复Modal默认挂载父级，新增用户可指定挂载父级

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
修复Modal默认挂载父级，同时新增用户可指定挂载父级API


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
