### PR TITLE
[Field] init方法可选参数新增checkable字段

### DIFF
--- a/src/components/field/demos/basic-forms.markdown
+++ b/src/components/field/demos/basic-forms.markdown
@@ -15,6 +15,10 @@ export default class FormHorizontalDemo extends React.Component {
 		}
 	});
 
+	state = {
+		emailCheckable: true
+	};
+
 	onValidate() {
 		this.field.validate((errs, values) => {
 			console.log(errs, values);
@@ -33,107 +37,122 @@ export default class FormHorizontalDemo extends React.Component {
 		this.field.clear();
 	}
 
+	onChange = emailCheckable => {
+		this.setState({ emailCheckable });
+	};
+
 	render() {
 		const { init } = this.field;
+		const { emailCheckable } = this.state;
 
 		return (
-			<Form layout="horizontal" labelCol={{ span: 6 }} field={this.field}>
-				<Form.Item label="用户名" help="使用了Form.Nexus组件，可以查看示例代码">
-					<User field={this.field} />
-				</Form.Item>
+			<>
+				<Form layout="horizontal" labelCol={{ span: 6 }} field={this.field}>
+					<Form.Item label="是否开启邮箱校验">
+						<Radio.Group value={emailCheckable} onChange={this.onChange}>
+							<Radio value={true}>开启</Radio>
+							<Radio value={false}>禁用</Radio>
+						</Radio.Group>
+					</Form.Item>
 
-				<Form.Item label="邮箱">
-					<Input
-						placeholder="请输入验证邮箱"
-						{...init('email', {
-							rules: [
-								{ required: true, message: '验证邮箱不能为空' },
-								{ pattern: /^\w+@[a-z]{2,10}\.[a-z]{2,8}$/, message: '邮箱格式不正确' }
-							]
-						})}
-					/>
-				</Form.Item>
+					<Form.Item label="用户名" help="使用了Form.Nexus组件，可以查看示例代码">
+						<User field={this.field} />
+					</Form.Item>
 
-				<Form.Item label="中奖次数">
-					<InputNumber
-						placeholder="请输入中奖次数"
-						{...init('number', {
-							rules: [{ required: true, message: '中奖次数不能为空' }, { min: 5 }, { max: 10 }]
-						})}
-					/>
-				</Form.Item>
+					<Form.Item label="邮箱">
+						<Input
+							placeholder="请输入验证邮箱"
+							{...init('email', {
+								checkable: emailCheckable,
+								rules: [
+									{ required: true, message: '验证邮箱不能为空' },
+									{ pattern: /^\w+@[a-z]{2,10}\.[a-z]{2,8}$/, message: '邮箱格式不正确' }
+								]
+							})}
+						/>
+					</Form.Item>
 
-				<Form.Item label="所在国家" required>
-					<Select
-						{...init('address', {
-							rules: [{ required: true, message: '所属地区不能为空' }]
-						})}>
-						<Select.Option value={1}>中国大陆</Select.Option>
-						<Select.Option value={2}>美国</Select.Option>
-						<Select.Option value={3}>日本</Select.Option>
-					</Select>
-				</Form.Item>
+					<Form.Item label="中奖次数">
+						<InputNumber
+							placeholder="请输入中奖次数"
+							{...init('number', {
+								rules: [{ required: true, message: '中奖次数不能为空' }, { min: 5 }, { max: 10 }]
+							})}
+						/>
+					</Form.Item>
 
-				<Form.Item label="是否开启" required>
-					<Toggle
-						checkedText="这里是开"
-						unCheckedText="这里是关"
-						{...init('toggle', {
-							valueName: 'checked',
-							rules: [{ required: true, message: '值不能为空' }]
-						})}
-					/>
-				</Form.Item>
+					<Form.Item label="所在国家" required>
+						<Select
+							{...init('address', {
+								rules: [{ required: true, message: '所属地区不能为空' }]
+							})}>
+							<Select.Option value={1}>中国大陆</Select.Option>
+							<Select.Option value={2}>美国</Select.Option>
+							<Select.Option value={3}>日本</Select.Option>
+						</Select>
+					</Form.Item>
 
-				<Form.Item label="性别" required>
-					<Radio.Group
-						{...init('gender', {
-							rules: [{ required: true, message: '性别不能为空' }]
-						})}>
-						<Radio value={1}>保密</Radio>
-						<Radio value={2}>先生</Radio>
-						<Radio value={3}>女士</Radio>
-					</Radio.Group>
-				</Form.Item>
+					<Form.Item label="是否开启" required>
+						<Toggle
+							checkedText="这里是开"
+							unCheckedText="这里是关"
+							{...init('toggle', {
+								valueName: 'checked',
+								rules: [{ required: true, message: '值不能为空' }]
+							})}
+						/>
+					</Form.Item>
 
-				<Form.Item label="所属平台" required>
-					<Checkbox.Group
-						{...init('platform', {
-							rules: [
-								{ required: true, message: '所属平台必须选择一项' },
-								{
-									validator: (name, value, callback) => {
-										setTimeout(() => {
-											callback(value.length < 2 ? '所属平台必须选择两个以上' : '');
-										}, 300);
+					<Form.Item label="性别" required>
+						<Radio.Group
+							{...init('gender', {
+								rules: [{ required: true, message: '性别不能为空' }]
+							})}>
+							<Radio value={1}>保密</Radio>
+							<Radio value={2}>先生</Radio>
+							<Radio value={3}>女士</Radio>
+						</Radio.Group>
+					</Form.Item>
+
+					<Form.Item label="所属平台" required>
+						<Checkbox.Group
+							{...init('platform', {
+								rules: [
+									{ required: true, message: '所属平台必须选择一项' },
+									{
+										validator: (name, value, callback) => {
+											setTimeout(() => {
+												callback(value.length < 2 ? '所属平台必须选择两个以上' : '');
+											}, 300);
+										}
 									}
-								}
-							]
-						})}>
-						<Checkbox value={1}>淘宝</Checkbox>
-						<Checkbox value={2}>京东</Checkbox>
-						<Checkbox value={3}>苏宁</Checkbox>
-						<Checkbox value={4}>蘑菇街</Checkbox>
-					</Checkbox.Group>
-				</Form.Item>
+								]
+							})}>
+							<Checkbox value={1}>淘宝</Checkbox>
+							<Checkbox value={2}>京东</Checkbox>
+							<Checkbox value={3}>苏宁</Checkbox>
+							<Checkbox value={4}>蘑菇街</Checkbox>
+						</Checkbox.Group>
+					</Form.Item>
 
-				<Form.Item label="备注">
-					<Input.Textarea autoSize minRows={2} placeholder="备注信息..." {...init('remarks')} />
-				</Form.Item>
+					<Form.Item label="备注">
+						<Input.Textarea autoSize minRows={2} placeholder="备注信息..." {...init('remarks')} />
+					</Form.Item>
 
-				<Form.Item wrapperCol={{ offset: 6 }}>
-					<Button type="primary" style={{ marginRight: 10 }} onClick={this.onValidate.bind(this)}>
-						提交
-					</Button>
-					<Button style={{ marginRight: 10 }} onClick={this.onReset.bind(this)}>
-						重置
-					</Button>
-					<Button style={{ marginRight: 10 }} onClick={this.onClear.bind(this)}>
-						清除
-					</Button>
-					<Button onClick={this.getValues.bind(this)}>获取所有值</Button>
-				</Form.Item>
-			</Form>
+					<Form.Item wrapperCol={{ offset: 6 }}>
+						<Button type="primary" style={{ marginRight: 10 }} onClick={this.onValidate.bind(this)}>
+							提交
+						</Button>
+						<Button style={{ marginRight: 10 }} onClick={this.onReset.bind(this)}>
+							重置
+						</Button>
+						<Button style={{ marginRight: 10 }} onClick={this.onClear.bind(this)}>
+							清除
+						</Button>
+						<Button onClick={this.getValues.bind(this)}>获取所有值</Button>
+					</Form.Item>
+				</Form>
+			</>
 		);
 	}
 }

--- a/src/components/field/index.md
+++ b/src/components/field/index.md
@@ -60,22 +60,20 @@ function Form() {
 
 `init(name[, options])`
 
-| 属性              | 说明                                                               | 类型                 | 默认值     |
-| ----------------- | ------------------------------------------------------------------ | -------------------- | ---------- |
-| name              | 必填输入控件唯一标志                                               | string               | -          |
-| options.initValue | 组件初始值，对控件件的`defaultValue`                               | any                  | -          |
-| options.valueName | 组件值的属性名称，如`Radio`的是`checked`，`Input`是`value`         | string               | `value`    |
-| options.trigger   | 触发取数据的方法，对应控件的 handle 方法，如`onChange`、`onSelect` | string               | `onChange` |
-| options.onChange  | 在组件触发`onChange`时调用                                         | Function(evt: event) | -          |
-| options.rules     | 校验规则                                                           | array                | -          |
+| 属性              | 说明                                                                      | 类型                 | 默认值     |
+| ----------------- | ------------------------------------------------------------------------- | -------------------- | ---------- |
+| name              | 必填输入控件唯一标志                                                      | string               | -          |
+| options.initValue | 组件初始值，对控件件的`defaultValue`                                      | any                  | -          |
+| options.valueName | 组件值的属性名称，如`Radio`的是`checked`，`Input`是`value`                | string               | `value`    |
+| options.trigger   | 触发取数据的方法，对应控件的 handle 方法，如`onChange`、`onSelect`        | string               | `onChange` |
+| options.onChange  | 在组件触发`onChange`时调用                                                | Function(evt: event) | -          |
+| options.rules     | 校验规则                                                                  | array                | -          |
+| options.checkable | 是否可校验，当设置为`false`时仅跳过该字段的校验，不会清空该字段的其他信息 | boolean              | `true`     |
 
 ### options.rules
 
 ```javascript
-[
-	{ required: true, message: '内容不允许为空' },
-	{ len: 20, message: '最长只能输入20个字符' }
-];
+[{ required: true, message: '内容不允许为空' }, { len: 20, message: '最长只能输入20个字符' }];
 ```
 
 | 属性      | 说明                                                                 | 类型                            | 默认值    |


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/ShuyunFF2E/cloud-react/issues/285

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 可选择性临时关闭某个字段的校验行为
2. `Field.prototype.init(name, [opts])`可选参数新增`checkable`字段

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
`Field.prototype.init(name, [opts])`可选参数新增`checkable`字段，可临时开启/关闭某个字段的校验行为


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
