### PR TITLE
[Form] 合并Form.Item和Form.Nexus渲染内容部分代码

### DIFF
--- a/src/components/form/form-item.js
+++ b/src/components/form/form-item.js
@@ -6,11 +6,12 @@ import { noop, prefixCls } from '@utils';
 
 import FormContext from './context';
 import Explain from './explain';
-import { LAYOUT_TYPES, DATA_FIELD, findFieldsName, getNamesByNode, findDestroyedFields } from './constants';
+import RenderChildren from './render-children';
+import { LAYOUT_TYPES, findFieldsName, getNamesByNode, findDestroyedFields } from './constants';
 
 const MAX_COL = 24;
 
-export default class Form extends Component {
+export default class FormItem extends Component {
 	static contextType = FormContext;
 
 	static propTypes = {
@@ -164,51 +165,10 @@ export default class Form extends Component {
 
 		return (
 			<div ref={this.wrapperRef} {...wrapperAttrs}>
-				{this.renderChildren(children)}
-				{<Explain>{help}</Explain>}
+				<RenderChildren field={this.field}>{children}</RenderChildren>
+				<Explain>{help}</Explain>
 			</div>
 		);
-	}
-
-	renderChildren(children) {
-		if (['object', 'string', 'array'].indexOf(typeof children) === -1) {
-			return children;
-		}
-
-		return Children.map(children, (child, key) => {
-			if (!child) return null;
-
-			const { props } = child;
-
-			if (!props) return child;
-
-			if (props && props[DATA_FIELD]) {
-				const { getState = noop, getError = noop } = this.field || {};
-
-				const state = getState.call(this.field, props[DATA_FIELD]);
-				const error = getError.call(this.field, props[DATA_FIELD]);
-
-				return (
-					<div
-						key={key.toString()}
-						className={classnames('contents', {
-							'has-error': state === 'error',
-							'has-success': state === 'success'
-						})}>
-						{cloneElement(child, child.props)}
-						{error ? <Explain className="error">{error}</Explain> : null}
-					</div>
-				);
-			}
-
-			let items = props.children;
-
-			if (props.children && Children.count(props.children) && !props[DATA_FIELD]) {
-				items = this.renderChildren(props.children);
-			}
-
-			return cloneElement(child, { key, ...child.props, children: items });
-		});
 	}
 
 	render() {

--- a/src/components/form/form-nexus.js
+++ b/src/components/form/form-nexus.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import FormContext from './context';
+import RenderChildren from './render-children';
+
+import { findFieldsName } from './constants';
+
+export default class FormNexus extends Component {
+	static contextType = FormContext;
+
+	static propTypes = {
+		children: PropTypes.any
+	};
+
+	static defaultProps = {
+		children: null
+	};
+
+	componentWillUnmount() {
+		const { field, dataFields } = this;
+
+		// 如果设置了校验规则，则重置并删除
+		if (field && field.remove && dataFields && dataFields.length) {
+			field.remove(dataFields);
+		}
+	}
+
+	get field() {
+		return this.context.field;
+	}
+
+	get fieldsMeta() {
+		if (this.field && this.field.fieldsMeta) {
+			return this.field.fieldsMeta;
+		}
+		return null;
+	}
+
+	get dataFields() {
+		const {
+			field,
+			props: { children }
+		} = this;
+		const fieldsName = findFieldsName(children);
+
+		if (field && field.fieldsMeta && fieldsName.length) {
+			return fieldsName;
+		}
+
+		return null;
+	}
+
+	render() {
+		const { children } = this.props;
+
+		return <RenderChildren field={this.field}>{children}</RenderChildren>;
+	}
+}

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { prefixCls } from '@utils';
 
 import FormItem from './form-item';
-import Nexus from './nexus';
+import Nexus from './form-nexus';
 import FormContext from './context';
 import { LAYOUT_TYPES, LABEL_ALIGN } from './constants';
 

--- a/src/components/form/render-children.js
+++ b/src/components/form/render-children.js
@@ -1,57 +1,23 @@
 import React, { Component, Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { noop } from '@utils';
 
-import FormContext from './context';
 import Explain from './explain';
 
-import { DATA_FIELD, findFieldsName } from './constants';
+import { DATA_FIELD } from './constants';
 
-export default class FormB extends Component {
-	static contextType = FormContext;
+export const noop = () => {};
 
+export default class RenderChildren extends Component {
 	static propTypes = {
-		children: PropTypes.any
+		children: PropTypes.any,
+		field: PropTypes.object
 	};
 
 	static defaultProps = {
-		children: null
+		children: null,
+		field: {}
 	};
-
-	componentWillUnmount() {
-		const { field, dataFields } = this;
-
-		// 如果设置了校验规则，则重置并删除
-		if (field && field.remove && dataFields && dataFields.length) {
-			field.remove(dataFields);
-		}
-	}
-
-	get field() {
-		return this.context.field;
-	}
-
-	get fieldsMeta() {
-		if (this.field && this.field.fieldsMeta) {
-			return this.field.fieldsMeta;
-		}
-		return null;
-	}
-
-	get dataFields() {
-		const {
-			field,
-			props: { children }
-		} = this;
-		const fieldsName = findFieldsName(children);
-
-		if (field && field.fieldsMeta && fieldsName.length) {
-			return fieldsName;
-		}
-
-		return null;
-	}
 
 	renderChildren(children) {
 		if (['object', 'string', 'array'].indexOf(typeof children) === -1) {
@@ -66,10 +32,11 @@ export default class FormB extends Component {
 			if (!props) return child;
 
 			if (props && props[DATA_FIELD]) {
-				const { getState = noop, getError = noop } = this.field || {};
+				const { field } = this.props;
+				const { getState = noop, getError = noop } = field;
 
-				const state = getState.call(this.field, props[DATA_FIELD]);
-				const error = getError.call(this.field, props[DATA_FIELD]);
+				const state = getState.call(field, props[DATA_FIELD]);
+				const error = getError.call(field, props[DATA_FIELD]);
 
 				return (
 					<div


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 其他改动（合并多个相同方法）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无相关issue

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 存在多个相同的方法

### 📝 更新日志怎么写？
1. 减少`Form.Item`和`Form.Nexus`的冗余代码

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
