### PR TITLE
[Modal]新增iframe嵌套时且在不跨域的情况将Modal挂载到可访问最高层窗口的body节点上

### DIFF
--- a/src/components/modal/demos/iframe.markdown
+++ b/src/components/modal/demos/iframe.markdown
@@ -1,0 +1,54 @@
+---
+order: 11
+title: iframe框架嵌套
+desc: 当iframe窗口里面的页面和父窗口不存在跨域时，弹框将默认挂载到父窗口，以此增强视觉效果
+---
+
+```javascript
+import React from 'react';
+
+const style = {
+	width: '100%',
+	height: '400px',
+	border: '2px solid #bad8e4'
+};
+
+export default class ModaliFrameDemo extends React.Component {
+	iframeRef = React.createRef();
+
+	get rootWindow() {
+		const { current: iframe } = this.iframeRef;
+
+		return iframe ? iframe.contentWindow : window;
+	}
+
+	componentDidMount() {
+		this.rootWindow.addEventListener('load', this.setStyle);
+	}
+
+	componentWillUnmount() {
+		this.rootWindow.removeEventListener('load', this.setStyle);
+	}
+
+	setStyle = () => {
+		const root = this.rootWindow.document.querySelector('#root');
+
+		const [menu, content] = root.children[0].children;
+
+		menu.style.display = 'none';
+		content.style.marginLeft = 0;
+	};
+
+	render() {
+		try {
+			if (window.top !== window) {
+				return '子窗口不再渲染iframe示例';
+			}
+		} catch (err) {
+			console.log(err);
+		}
+
+		return <iframe ref={this.iframeRef} src="/#/组件/modal" style={style} />;
+	}
+}
+```

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
+import { getRootDocument } from '@utils';
 import './index.less';
 import Notification from './modal';
 import Prompt from './prompt';
@@ -13,7 +14,7 @@ class Modal extends Component {
 	};
 
 	static defaultProps = {
-		getPopupContainer: () => document.body,
+		getPopupContainer: () => getRootDocument().body,
 		children: null
 	};
 

--- a/src/components/modal/index.less
+++ b/src/components/modal/index.less
@@ -33,8 +33,7 @@
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background: @color-gray2;
-		opacity: 0.6;
+		background: rgba(102, 102, 102, 0.55);
 	}
 
 	&-container {
@@ -43,45 +42,52 @@
 		max-width: 50%;
 		margin: 0 auto;
 		position: relative;
+		top: 20%;
 		background: @color-gray1;
 		border-radius: @body-border-radius;
 		white-space: normal;
-		animation: modal-fade-in 0.5s;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.13);
+		opacity: 0;
 
-		@-webkit-keyframes modal-fade-in {
-			0% {
-				opacity: 0;
-				top: 0;
-			}
-			100% {
-				opacity: 1;
-			}
+		&.transition {
+			transition: 0.3s cubic-bezier(0, 0.71, 0.77, 1);
 		}
 	}
 
 	&-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		height: 42px;
 		border-radius: 2px;
-		padding: 10px 14px 10px 17px;
-		text-align: left;
+		padding: 0 20px;
 		font-size: 14px;
 		background: @header-background;
-		.@{modal-prefix-cls}-title {
-			color: @color-gray2;
-			cursor: text;
+
+		&:active {
+			cursor: move;
 		}
 
 		.close-icon {
-			float: right;
 			position: relative;
 			color: @close-icon-color;
+			transform: scale(1.3);
 			cursor: pointer;
+
+			&:hover {
+				color: #a5a5a5;
+			}
+		}
+
+		.@{modal-prefix-cls}-title {
+			color: @color-gray2;
+			cursor: text;
 		}
 	}
 
 	&-body {
 		max-height: calc(100vh - 200px);
 		min-height: 80px;
-		// font-size: 14px;
 		color: @color-gray4;
 		padding: 20px;
 		overflow: auto;

--- a/src/components/modal/prompt.js
+++ b/src/components/modal/prompt.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import { getRootDocument } from '@utils';
 import Icon from '../icon';
 import Notification from './modal';
 
@@ -18,10 +19,12 @@ class Prompt extends React.Component {
 		icon: '',
 		body: '',
 		onOk: () => {},
-		onCancel: () => {}
+		onCancel: () => {},
+		getPopupContainer: () => getRootDocument().body
 	};
 
 	static propTypes = {
+		getPopupContainer: PropTypes.func,
 		isShowIcon: PropTypes.bool,
 		style: PropTypes.object,
 		type: PropTypes.string,
@@ -114,7 +117,7 @@ class Prompt extends React.Component {
 	};
 
 	render() {
-		const { isShowIcon, type, icon, body, iconStyle, style } = this.props;
+		const { isShowIcon, type, icon, body, iconStyle, style, getPopupContainer } = this.props;
 		const promptStyle = {
 			...style,
 			width: style.width || '400px',
@@ -128,15 +131,15 @@ class Prompt extends React.Component {
 			minHeight: style.height && 'calc(100% - 40px - 51px)'
 		};
 
-		return (
+		return ReactDOM.createPortal(
 			<Notification
 				visible
 				type={type}
-				modalStyle={promptStyle}
-				bodyStyle={promptBodyStyle}
-				showConfirmLoading={this.state.showConfirmLoading}
+				onOk={this.handleOk}
 				onCancel={this.handleCancel}
-				onOk={this.handleOk}>
+				bodyStyle={promptBodyStyle}
+				modalStyle={promptStyle}
+				showConfirmLoading={this.state.showConfirmLoading}>
 				<div>
 					<header className="info-area">
 						{isShowIcon && <Icon type={icon} className={`icon-style ${type}-style`} style={iconStyle} />}
@@ -145,7 +148,8 @@ class Prompt extends React.Component {
 						</section>
 					</header>
 				</div>
-			</Notification>
+			</Notification>,
+			getPopupContainer()
 		);
 	}
 }

--- a/src/utils/get-root-document.js
+++ b/src/utils/get-root-document.js
@@ -1,0 +1,19 @@
+export default function getRootDocument() {
+	let _document = window.document;
+
+	const getDocument = contextWindow => {
+		try {
+			if (_document === contextWindow.parent.document) {
+				return _document;
+			}
+
+			_document = contextWindow.parent.document;
+
+			return getDocument(contextWindow.parent);
+		} catch (_) {
+			return _document;
+		}
+	};
+
+	return getDocument(window);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 import noop from './noop';
 import omit from './omit';
+import getRootDocument from './get-root-document';
 import { prefixCls } from './config';
 
-export { noop, omit, prefixCls };
+export { noop, omit, prefixCls, getRootDocument };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 站点、文档改进
- [x] 组件样式改进
- [x] 重构

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
当项目在被嵌套在一个iframe框架中的时候，弹框无法挂载到相同域上的父窗口问题

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 当使用弹框的项目被嵌套在iframe窗口时，弹框不能全屏显示
2. 无API变更，在组件内部挂载之前查到了可挂载的顶层父窗口

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
新增`Modal`组件在iframe嵌套时可智能挂载到所能访问的最高层级父窗口
修复`Modal`组件在拖拽时会存在选中页面文字bug
修复`Modal`跨iframe交互时动画效果卡顿bug


### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
