### PR TITLE
:bug: [Tree] 输入关键字搜索，新增目录，清除搜索内容重新搜索，结果错误

### DIFF
--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -202,22 +202,21 @@ class Tree extends Component {
 	 * 新增节点
 	 * @param pId
 	 * @param value
+	 * @param pLevel
 	 */
 	onAddAction = (pId, value, pLevel) => {
 		const { onAddNode, isAddFront, maxLevel } = this.props;
 		onAddNode(pId, value)
 			.then(res => {
-				const data = store.addChildNode(
-					this.state.treeData,
-					pId,
-					{ id: res.data || res.id, name: value, children: [], pId, level: pLevel + 1, disableAdd: maxLevel - pLevel === 1 },
-					isAddFront
-				);
+				const newNode = { id: res.data || res.id, name: value, children: [], pId, level: pLevel + 1, disableAdd: maxLevel - pLevel === 1 };
+				const treeData = store.addChildNode(this.state.treeData, pId, newNode, isAddFront);
+				const allTreeData = store.addChildNode(this.state.allTreeData, pId, newNode, isAddFront);
 				// 新增之后重新init判断层级，不然会出现无层级可继续添加问题
 				this.setState({
-					treeData: jEasy.clone(data),
-					allTreeData: jEasy.clone(data)
+					treeData: jEasy.clone(treeData),
+					allTreeData: jEasy.clone(allTreeData)
 				});
+				Message.success('添加成功');
 			})
 			.catch(() => {
 				Message.error('添加失败');
@@ -233,10 +232,11 @@ class Tree extends Component {
 		const { onRenameNode } = this.props;
 		onRenameNode(id, newValue)
 			.then(() => {
-				const data = store.renameChildNode(this.state.treeData, id, newValue);
+				const treeData = store.renameChildNode(this.state.treeData, id, newValue);
+				const allTreeData = store.renameChildNode(this.state.allTreeData, id, newValue);
 				this.setState({
-					treeData: jEasy.clone(data),
-					allTreeData: jEasy.clone(data)
+					treeData: jEasy.clone(treeData),
+					allTreeData: jEasy.clone(allTreeData)
 				});
 				Message.success('更新成功');
 			})
@@ -265,11 +265,11 @@ class Tree extends Component {
 			onOk: () => {
 				onRemoveNode(node.id, node)
 					.then(() => {
-						// 删除DOM节点
-						const data = store.removeChildNode(this.state.treeData, node);
+						const treeData = store.removeChildNode(this.state.treeData, node);
+						const allTreeData = store.removeChildNode(this.state.allTreeData, node, false);
 						this.setState({
-							treeData: jEasy.clone(data),
-							allTreeData: jEasy.clone(data)
+							treeData: jEasy.clone(treeData),
+							allTreeData: jEasy.clone(allTreeData)
 						});
 					})
 					.catch(() => {

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -31,8 +31,7 @@ class Store {
 
 		// 递归向上查找选择
 		const upFind = currentNode => {
-			// eslint-disable-next-line no-param-reassign
-			currentNode.indeterminate = true;
+			Object.assign(currentNode, { indeterminate: true });
 			// 被选节点没有子节点则找到父节点对其进行半选
 			const pNode = this.findNodeById(cloneData, currentNode.pId);
 			// 没有父节点则不再查找
@@ -48,15 +47,13 @@ class Store {
 
 		// 递归向下查找选择
 		const downFind = currentNode => {
-			// eslint-disable-next-line no-param-reassign
-			currentNode.checked = true;
+			Object.assign(currentNode, { checked: true });
 			// 没有子节点则不再进行查找
 			if (!currentNode.children || !currentNode.children.length) {
 				return;
 			}
 			currentNode.children.forEach(son => {
-				// eslint-disable-next-line no-param-reassign
-				son.checked = true;
+				Object.assign(son, { checked: true });
 				downFind(son);
 			});
 		};
@@ -127,16 +124,10 @@ class Store {
 	 */
 	onResetData = data => {
 		const format = item => {
-			// eslint-disable-next-line no-param-reassign
-			item.indeterminate = false;
-			// eslint-disable-next-line no-param-reassign
-			item.checked = false;
+			Object.assign(item, { indeterminate: false, checked: false });
 			if (item.children && item.children.length) {
 				item.children.forEach(i => {
-					// eslint-disable-next-line no-param-reassign
-					i.indeterminate = false;
-					// eslint-disable-next-line no-param-reassign
-					i.checked = false;
+					Object.assign(i, { indeterminate: false, checked: false });
 					format(i);
 				});
 			}
@@ -184,8 +175,7 @@ class Store {
 	 */
 	selectedForCheckbox(data, node) {
 		const { checked, children, pId } = node;
-		// eslint-disable-next-line no-param-reassign
-		node.indeterminate = false;
+		Object.assign(node, { indeterminate: false });
 		// 变更自身节点选中状态
 		if (node.children && node.children.length) {
 			node.children.forEach(item => {
@@ -339,11 +329,9 @@ class Store {
 		}
 		if (isAddFront) {
 			pNode.children.unshift(newNode);
-			Message.success('添加成功');
 			return data;
 		}
 		pNode.children.push(newNode);
-		Message.success('添加成功');
 		return data;
 	}
 
@@ -367,14 +355,17 @@ class Store {
 	 * 删除节点
 	 * @param data
 	 * @param node
+	 * @param showErrorMsg
 	 * @returns {*}
 	 */
-	removeChildNode(data, node) {
+	removeChildNode(data, node, showErrorMsg = true) {
 		const parentNode = this.findNodeById(data, node.pId);
 
 		// 存在子节点则不可删除
 		if (!parentNode || node.children.length) {
-			Message.error('该目录存在子目录，不可删除!');
+			if (showErrorMsg) {
+				Message.error('该目录存在子目录，不可删除!');
+			}
 			return data;
 		}
 		parentNode.children.forEach((child, index) => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？
-   [ ] 新特性提交
-   [x] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 重构
-   [ ] 代码风格优化
-   [ ] 其他改动（是关于什么的改动？）

### bug 原因：
原来的代码中 treeData 和 allTreeData 分别用来渲染树和作为搜索树的数据源。在搜索后的基础上进行添加/编辑/删除目录操作，这个时候会同时更新 treeData 和 allTreeData，更新数据的数据源是经过筛选的 treeData(不是完整的treeData)，因此导致 allTreeData 不是都有的数据了，再次进行搜索的时候，就会出问题。

