### PR TITLE
:bug:[Form]修复组件内部使用了Object.values低版本浏览器不支持问题

### DIFF
--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -16,8 +16,8 @@ export default class Form extends Component {
 		field: PropTypes.object,
 		colon: PropTypes.bool,
 		className: PropTypes.string,
-		layout: PropTypes.oneOf(Object.values(LAYOUT_TYPES)),
-		labelAlign: PropTypes.oneOf(Object.values(LABEL_ALIGN)),
+		layout: PropTypes.oneOf([LAYOUT_TYPES.HORIZONTAL, LAYOUT_TYPES.VERTICAL, LAYOUT_TYPES.INLINE]),
+		labelAlign: PropTypes.oneOf([LABEL_ALIGN.LEFT, LABEL_ALIGN.RIGHT]),
 		labelCol: PropTypes.shape({
 			span: PropTypes.number,
 			offset: PropTypes.number


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
使用对浏览器版本过高的特性导致低版本浏览器不支持报错问题

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 使用对浏览器版本过高的特性导致低版本浏览器不支持报错问题
2. 改用通用的特性

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
修复Form组件使用了Object.values方法导致低版本浏览器不支持bug
