### PR TITLE
[Modal]修改弹框组件使用时可选择是否挂载到iframe之外的顶层父级

### DIFF
--- a/src/components/modal/demos/nest.markdown
+++ b/src/components/modal/demos/nest.markdown
@@ -53,7 +53,13 @@ export default class ModalDemo extends React.Component {
 				<Button type="normal" onClick={this.openNestModal}>
 					打开嵌套弹出框
 				</Button>
-				<Modal title="basic title" visible={this.state.visible} onOk={this.handleOk} onCancel={this.handleCancel} onClose={this.handleClose}>
+				<Modal
+					ignoreFrame
+					title="basic title"
+					visible={this.state.visible}
+					onOk={this.handleOk}
+					onCancel={this.handleCancel}
+					onClose={this.handleClose}>
 					<SecondModal />
 				</Modal>
 			</div>

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -9,17 +9,17 @@ import Prompt from './prompt';
 
 class Modal extends Component {
 	static propTypes = {
-		getPopupContainer: PropTypes.func,
+		ignoreFrame: PropTypes.bool,
 		children: PropTypes.any
 	};
 
 	static defaultProps = {
-		getPopupContainer: () => getRootDocument().body,
+		ignoreFrame: false,
 		children: null
 	};
 
 	render() {
-		const { getPopupContainer, children, ...props } = this.props;
+		const { children, ...props } = this.props;
 
 		const Child = (
 			<Notification type="modal" {...props}>
@@ -27,7 +27,7 @@ class Modal extends Component {
 			</Notification>
 		);
 
-		return ReactDOM.createPortal(Child, getPopupContainer());
+		return ReactDOM.createPortal(Child, getRootDocument(props.ignoreFrame).body);
 	}
 }
 

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -12,25 +12,25 @@ subtitle: 弹出框
 
 ### Modal
 
-| 属性               | 说明                                     | 类型                | 默认值              |
-| ------------------ | ---------------------------------------- | ------------------- | ------------------- |
-| visible            | 是否显示 modal 弹出框                    | boolean             | false               |
-| title              | 弹出框的标题                             | string              | title               |
-| modalStyle         | 设置弹出框样式                           | object              | -                   |
-| bodyStyle          | 设置弹出框内容区域样式                   | object              | -                   |
-| disabledOk         | 禁用确认按钮                             | boolean             | false               |
-| className          | 设置弹出框样式名称                       | string              | -                   |
-| hasFooter          | 是否显示底部区域                         | boolean             | true                |
-| footer             | modal 底部内容区域                       | string 或 ReactNode | -                   |
-| onClose            | 点击右上角关闭按钮时触发的回调           | function            | -                   |
-| onOk               | 点击确定按钮时触发的回调                 | function            | -                   |
-| onCancel           | 点击取消按钮时触发的回调                 | function            | -                   |
-| okText             | 确定按钮自定义文本                       | string              | 确定                |
-| cancelText         | 取消按钮自定义文本                       | string              | 取消                |
-| showMask           | 是否显示遮罩层                           | boolean             | true                |
-| clickMaskCanClose  | 点击遮罩层是否关闭, showMask 必须为 true | boolean             | true                |
-| showConfirmLoading | 点击确定是否显示 loading，用于异步关闭   | boolean             | false               |
-| getPopupContainer  | Modal 渲染的父节点                       | function            | () => document.body |
+| 属性               | 说明                                                                          | 类型                | 默认值  |
+| ------------------ | ----------------------------------------------------------------------------- | ------------------- | ------- |
+| visible            | 是否显示 modal 弹出框                                                         | boolean             | `false` |
+| title              | 弹出框的标题                                                                  | string              | `title` |
+| modalStyle         | 设置弹出框样式                                                                | object              | -       |
+| bodyStyle          | 设置弹出框内容区域样式                                                        | object              | -       |
+| disabledOk         | 禁用确认按钮                                                                  | boolean             | `false` |
+| className          | 设置弹出框样式名称                                                            | string              | -       |
+| hasFooter          | 是否显示底部区域                                                              | boolean             | `true`  |
+| footer             | modal 底部内容区域                                                            | string 或 ReactNode | -       |
+| onClose            | 点击右上角关闭按钮时触发的回调                                                | function            | -       |
+| onOk               | 点击确定按钮时触发的回调                                                      | function            | -       |
+| onCancel           | 点击取消按钮时触发的回调                                                      | function            | -       |
+| okText             | 确定按钮自定义文本                                                            | string              | `确定`  |
+| cancelText         | 取消按钮自定义文本                                                            | string              | `取消`  |
+| showMask           | 是否显示遮罩层                                                                | boolean             | `true`  |
+| clickMaskCanClose  | 点击遮罩层是否关闭, showMask 必须为 true                                      | boolean             | `true`  |
+| showConfirmLoading | 点击确定是否显示 loading，用于异步关闭                                        | boolean             | `false` |
+| ignoreFrame        | 忽略 iframe 框架限制，设置为`true`时将`Modal`组件挂载到顶层窗口的`body`容器中 | boolean             | `false` |
 
 ### Modal.method()
 

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -6,8 +6,6 @@ import Icon from '../icon';
 import Button from '../button';
 import './index.less';
 
-const rootDocument = getRootDocument();
-
 class Notification extends Component {
 	constructor(props) {
 		super(props);
@@ -35,6 +33,7 @@ class Notification extends Component {
 		cancelText: '取消',
 		clickMaskCanClose: true,
 		showConfirmLoading: false,
+		ignoreFrame: false,
 		onOk: () => {},
 		onCancel: () => {},
 		onClose: () => {}
@@ -56,7 +55,8 @@ class Notification extends Component {
 		onClose: PropTypes.func,
 		showMask: PropTypes.bool,
 		showConfirmLoading: PropTypes.bool,
-		clickMaskCanClose: PropTypes.bool
+		clickMaskCanClose: PropTypes.bool,
+		ignoreFrame: PropTypes.bool
 	};
 
 	// 组件装在完毕监听屏幕大小切换事件
@@ -82,9 +82,11 @@ class Notification extends Component {
 		window.removeEventListener('resize', this.screenChange);
 	}
 
+	rootDocument = getRootDocument(this.props.ignoreFrame);
+
 	/* eslint-disable-next-line */
 	get mask() {
-		return rootDocument.getElementById('mask');
+		return this.rootDocument.getElementById('mask');
 	}
 
 	// 屏幕变化
@@ -134,8 +136,8 @@ class Notification extends Component {
 	onMouseDown = evt => {
 		const { diffX, diffY } = this.getPosition(evt);
 
-		rootDocument.addEventListener('mousemove', this.onMouseMove);
-		rootDocument.addEventListener('mouseup', this.onMouseUp);
+		this.rootDocument.addEventListener('mousemove', this.onMouseMove);
+		this.rootDocument.addEventListener('mouseup', this.onMouseUp);
 
 		this.removeTransition();
 		this.setState({ diffX, diffY });
@@ -143,8 +145,8 @@ class Notification extends Component {
 
 	// 松开鼠标
 	onMouseUp = () => {
-		rootDocument.removeEventListener('mousemove', this.onMouseMove);
-		rootDocument.removeEventListener('mouseup', this.onMouseUp);
+		this.rootDocument.removeEventListener('mousemove', this.onMouseMove);
+		this.rootDocument.removeEventListener('mouseup', this.onMouseUp);
 	};
 
 	// 鼠标移动重新设置modal的位置
@@ -159,7 +161,7 @@ class Notification extends Component {
 			const y = position.mouseY - diffY;
 
 			// 窗口大小，结构限制，需要做调整，减去侧边栏宽度
-			const { clientWidth, clientHeight } = rootDocument.documentElement;
+			const { clientWidth, clientHeight } = this.rootDocument.documentElement;
 			const modal = this.modalRef;
 
 			if (modal) {

--- a/src/components/modal/prompt.js
+++ b/src/components/modal/prompt.js
@@ -20,7 +20,8 @@ class Prompt extends React.Component {
 		body: '',
 		onOk: () => {},
 		onCancel: () => {},
-		getPopupContainer: () => getRootDocument().body
+		// 暂时关闭Modal.method类型组件无视iframe嵌套问题
+		getPopupContainer: () => getRootDocument(false).body
 	};
 
 	static propTypes = {

--- a/src/utils/get-root-document.js
+++ b/src/utils/get-root-document.js
@@ -1,5 +1,7 @@
-export default function getRootDocument() {
+export default function getRootDocument(ignoreFrame) {
 	let _document = window.document;
+
+	if (!ignoreFrame) return _document;
 
 	const getDocument = contextWindow => {
 		try {


### PR DESCRIPTION
### 🤔 这个变动的性质是？
-   [x] 新特性提交

### 💡 需求背景和解决方案
新增参数让开发者可选择是否要将Modal组件挂载到iframe（如果有的话）之外的父窗口上


### 📝 更新日志怎么写？
新增Modal组件是否可以挂载到iframe的顶层窗口

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充或无须补充
-   [ ] 代码演示已提供或无须提供
