### PR TITLE
[Modal]新增createModal方法，修复modal中message引用索引错误问题

### DIFF
--- a/src/components/modal/demos/methodModal.markdown
+++ b/src/components/modal/demos/methodModal.markdown
@@ -1,0 +1,64 @@
+---
+order: 13
+title: 方法打开弹框
+desc: 使用createModal方法创建一个弹出框，open方法打开
+---
+
+```javascript
+import React from 'react';
+import { Button, Modal } from 'cloud-react';
+
+export default class ModalDemo extends React.Component {
+	// 弹出框
+	openNestModal = () => {
+		const modalStyle = {
+			width: '600px'
+		};
+		const bodyStyle = {
+			width: 'auto',
+			fontSize: '20px',
+			color: 'green',
+			height: '100px',
+			overflow: 'auto'
+		};
+		const attr = {
+			title: '方法打开',
+			bodyStyle: bodyStyle,
+			className: 'test',
+			modalStyle: modalStyle
+		};
+
+		Modal.createModal({ body: <SecondModal />, attributes: attr })
+			.open()
+			.then(res => {
+				console.log(res);
+			});
+	};
+
+	// 确认按钮回调函数
+	handleOk = () => {
+		console.log('it is ok');
+	};
+
+	// 关闭回调函数
+	handleClose = () => {
+		console.log('it is close');
+	};
+
+	render() {
+		return (
+			<div>
+				<Button type="normal" onClick={this.openNestModal}>
+					打开弹出框
+				</Button>
+			</div>
+		);
+	}
+}
+
+class SecondModal extends React.Component {
+	render() {
+		return <div>这是一个通过createModal方法创建的modal，接受字符串、html、JSX</div>;
+	}
+}
+```

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-
 import { getRootDocument } from '@utils';
+import Message from '../message';
 import './index.less';
 import Notification from './modal';
 import Prompt from './prompt';
+
+let container = null;
 
 class Modal extends Component {
 	static propTypes = {
@@ -30,6 +32,72 @@ class Modal extends Component {
 		return ReactDOM.createPortal(Child, getRootDocument(props.ignoreFrame).body);
 	}
 }
+
+export function randomId(len) {
+	const genUnit = () =>
+		Math.random()
+			.toString(36)
+			.substr(2);
+
+	const randomUnit = genUnit();
+	if (len <= 0) return randomUnit;
+	if (len <= 11) return randomUnit.substr(0, len);
+
+	let rs = '';
+	while (rs.length < len) {
+		rs += genUnit();
+	}
+	return rs.substr(0, len);
+}
+
+Modal.createModal = props => {
+	if (!props) {
+		return Message.error('未创建弹出框内容');
+	}
+	const { body, attributes } = props;
+	const containerId = randomId(10);
+	const close = () => {
+		if (container) {
+			setTimeout(() => {
+				ReactDOM.unmountComponentAtNode(container);
+				document.body.removeChild(container);
+			});
+		}
+	};
+
+	const open = () => {
+		container = document.getElementById(containerId);
+		if (!container) {
+			container = document.createElement('div');
+			container.id = containerId;
+			document.body.appendChild(container);
+		}
+		return new Promise(resolve => {
+			function handleClose() {
+				close();
+			}
+			function handleCancel() {
+				close();
+			}
+			function handleOk(result) {
+				close();
+				resolve(result);
+			}
+
+			ReactDOM.render(
+				<Modal visible onCancel={handleCancel} onClose={handleClose} onOk={handleOk} {...attributes}>
+					{body}
+				</Modal>,
+				container
+			);
+		});
+	};
+
+	return {
+		open,
+		close
+	};
+};
 
 // confirm方法
 Modal.confirm = props => {

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -32,7 +32,16 @@ subtitle: 弹出框
 | showConfirmLoading | 点击确定是否显示 loading，用于异步关闭                                        | boolean             | `false` |
 | ignoreFrame        | 忽略 iframe 框架限制，设置为`true`时将`Modal`组件挂载到顶层窗口的`body`容器中 | boolean             | `false` |
 
-### Modal.method()
+### Modal.createModal()
+
+通过 createModal 创建弹框，通过 open 方式打开弹框，createModal 接受两个参数（具体用法查看示例：方法打开弹框）：
+
+| 参数名     | 说明                                                                                  | 类型   | 默认值 |
+| ---------- | ------------------------------------------------------------------------------------- | ------ | ------ |
+| body       | 弹框内容, 支持 jsx 语法直接传入 dom 节点，也支持 html，string                         | any    | `--`   |
+| attributes | 需要的使用属性集合，参考 modal 属性，不支持 onOk，onClose，onCancel，visible 四个属性 | object | `--`   |
+
+### Modal method
 
 包括：
 
@@ -42,7 +51,7 @@ subtitle: 弹出框
 -   Modal.info()
 -   Modal.warning()
 
-以上均为一个函数，参数为 object，具体属性如下：
+以上均为函数，参数为 object，具体属性如下：
 
 | 方法名     | 说明                                          | 类型     | 默认值 |
 | ---------- | --------------------------------------------- | -------- | ------ |

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -116,11 +116,12 @@ class Notification extends Component {
 		if (!this.modalRef || !this.modalRef.style || this.state.pageY) return;
 
 		window.requestAnimationFrame(() => {
-			const maskHeight = this.mask.offsetHeight;
-			const modalHeight = this.modalRef.offsetHeight;
-
-			this.modalRef.style.top = `${(maskHeight - modalHeight) / 2}px`;
-			this.modalRef.style.opacity = 1;
+			const maskHeight = this.mask && this.mask.offsetHeight;
+			const modalHeight = this.modalRef && this.modalRef.offsetHeight;
+			if (this.modalRef) {
+				this.modalRef.style.top = `${(maskHeight - modalHeight) / 2}px`;
+				this.modalRef.style.opacity = 1;
+			}
 		});
 	};
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请提交至 develop 分支
在维护者审核通过后合并。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [X] 新特性提交
-   [X] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 重构
-   [ ] 代码风格优化
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/ShuyunFF2E/cloud-react/issues/340

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、在使用modal时需要提供一个公共方法用于打开modal，而不是使用visible进行手动控制，所以在原先的基础上增加createModal方法用于创建modal，同时兼容原来的写法；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、新增createModal方法，通过open的方式打开弹出框；
2、修复modal组件中引用Message组件索引错误导致报错问题；

### ☑️ 请求合并前的自查清单

-   [X] 文档已补充或无须补充
-   [X] 代码演示已提供或无须提供
