### PR TITLE
:art: [Tree][TreeSelect] 样式和交互优化

### DIFF
--- a/src/components/tree-select/demos/multiple.markdown
+++ b/src/components/tree-select/demos/multiple.markdown
@@ -9,6 +9,168 @@ import React from 'react';
 import { TreeSelect } from 'cloud-react';
 
 export default class TreeSelectDemo extends React.Component {
+	treeData = [
+		{
+			id: 11,
+			name: '禁止删除节点',
+			pId: 1,
+			disableRemove: true,
+			children: [
+				{
+					id: 111,
+					name: '超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点超长的节点',
+					pId: 11,
+					children: []
+				},
+				{
+					id: 112,
+					name: '删除两个',
+					pId: 11,
+					children: []
+				},
+				{
+					id: 113,
+					name: '删除三个',
+					pId: 11,
+					children: [
+						{
+							id: 1131,
+							name: '禁止删除节点31',
+							pId: 113,
+							children: []
+						},
+						{
+							id: 1132,
+							name: '禁止删除节点32',
+							pId: 113,
+							children: [
+								{
+									id: 11321,
+									name: '禁止删除节点321',
+									pId: 1132,
+									children: []
+								}
+							]
+						}
+					]
+				},
+				{
+					id: 114,
+					name: '禁止删除节点4',
+					pId: 11,
+					children: []
+				}
+			]
+		},
+		{
+			id: 12,
+			name: '禁止新增节点',
+			pId: 1,
+			disableAdd: true,
+			children: [
+				{
+					id: 121,
+					name: '禁止新增节点1',
+					pId: 12,
+					children: [
+						{
+							id: 1211,
+							name: '禁止新增节点11',
+							pId: 121,
+							children: []
+						},
+						{
+							id: 1212,
+							name: '禁止新增节点12',
+							pId: 121,
+							children: []
+						},
+						{
+							id: 1213,
+							name: '禁止新增节点13',
+							pId: 121,
+							children: []
+						}
+					]
+				},
+				{
+					id: 122,
+					name: '禁止新增节点2',
+					pId: 12,
+					children: [
+						{
+							id: 1221,
+							name: '禁止新增节点21',
+							pId: 122,
+							children: []
+						},
+						{
+							id: 1222,
+							name: '禁止新增节点22',
+							pId: 122,
+							children: []
+						}
+					]
+				}
+			]
+		},
+		{
+			id: 13,
+			name: '禁止重命名节点',
+			pId: 1,
+			disableRename: true,
+			children: [
+				{
+					id: 131,
+					name: '禁止重命名节点1',
+					pId: 13,
+					children: [
+						{
+							id: 1311,
+							name: '禁止重命名节点11',
+							pId: 131,
+							children: []
+						},
+						{
+							id: 1312,
+							name: '禁止重命名节点12',
+							pId: 131,
+							children: []
+						},
+						{
+							id: 1313,
+							name: '禁止重命名节点13',
+							pId: 131,
+							children: []
+						}
+					]
+				},
+				{
+					id: 132,
+					name: '禁止重命名节点2',
+					pId: 13,
+					children: [
+						{
+							id: 1321,
+							name: '禁止重命名节点21',
+							pId: 132,
+							children: []
+						}
+					]
+				}
+			]
+		},
+		{
+			id: 14,
+			name: '未分类',
+			pId: 1,
+			disableRemove: true,
+			disableAdd: true,
+			disableRename: true,
+			children: []
+		}
+	];
+
 	constructor(props) {
 		super(props);
 
@@ -20,13 +182,7 @@ export default class TreeSelectDemo extends React.Component {
 					pId: 11
 				}
 			],
-			confirmNodes: [
-				{
-					id: 112,
-					name: '删除两个',
-					pId: 11
-				}
-			],
+			confirmNodes: [],
 			singleNodes: [
 				{
 					id: 112,
@@ -35,6 +191,18 @@ export default class TreeSelectDemo extends React.Component {
 				}
 			]
 		};
+
+		setTimeout(() => {
+			this.setState({
+				confirmNodes: [
+					{
+						id: 112,
+						name: '删除两个',
+						pId: 11
+					}
+				]
+			});
+		}, 1000);
 	}
 
 	handleChange = (node, selectedNodes) => {
@@ -62,168 +230,6 @@ export default class TreeSelectDemo extends React.Component {
 	};
 
 	render() {
-		const treeData = [
-			{
-				id: 11,
-				name: '禁止删除节点',
-				pId: 1,
-				disableRemove: true,
-				children: [
-					{
-						id: 111,
-						name: '删除一个',
-						pId: 11,
-						children: []
-					},
-					{
-						id: 112,
-						name: '删除两个',
-						pId: 11,
-						children: []
-					},
-					{
-						id: 113,
-						name: '删除三个',
-						pId: 11,
-						children: [
-							{
-								id: 1131,
-								name: '禁止删除节点31',
-								pId: 113,
-								children: []
-							},
-							{
-								id: 1132,
-								name: '禁止删除节点32',
-								pId: 113,
-								children: [
-									{
-										id: 11321,
-										name: '禁止删除节点321',
-										pId: 1132,
-										children: []
-									}
-								]
-							}
-						]
-					},
-					{
-						id: 114,
-						name: '禁止删除节点4',
-						pId: 11,
-						children: []
-					}
-				]
-			},
-			{
-				id: 12,
-				name: '禁止新增节点',
-				pId: 1,
-				disableAdd: true,
-				children: [
-					{
-						id: 121,
-						name: '禁止新增节点1',
-						pId: 12,
-						children: [
-							{
-								id: 1211,
-								name: '禁止新增节点11',
-								pId: 121,
-								children: []
-							},
-							{
-								id: 1212,
-								name: '禁止新增节点12',
-								pId: 121,
-								children: []
-							},
-							{
-								id: 1213,
-								name: '禁止新增节点13',
-								pId: 121,
-								children: []
-							}
-						]
-					},
-					{
-						id: 122,
-						name: '禁止新增节点2',
-						pId: 12,
-						children: [
-							{
-								id: 1221,
-								name: '禁止新增节点21',
-								pId: 122,
-								children: []
-							},
-							{
-								id: 1222,
-								name: '禁止新增节点22',
-								pId: 122,
-								children: []
-							}
-						]
-					}
-				]
-			},
-			{
-				id: 13,
-				name: '禁止重命名节点',
-				pId: 1,
-				disableRename: true,
-				children: [
-					{
-						id: 131,
-						name: '禁止重命名节点1',
-						pId: 13,
-						children: [
-							{
-								id: 1311,
-								name: '禁止重命名节点11',
-								pId: 131,
-								children: []
-							},
-							{
-								id: 1312,
-								name: '禁止重命名节点12',
-								pId: 131,
-								children: []
-							},
-							{
-								id: 1313,
-								name: '禁止重命名节点13',
-								pId: 131,
-								children: []
-							}
-						]
-					},
-					{
-						id: 132,
-						name: '禁止重命名节点2',
-						pId: 13,
-						children: [
-							{
-								id: 1321,
-								name: '禁止重命名节点21',
-								pId: 132,
-								children: []
-							}
-						]
-					}
-				]
-			},
-			{
-				id: 14,
-				name: '未分类',
-				pId: 1,
-				disableRemove: true,
-				disableAdd: true,
-				disableRename: true,
-				children: []
-			}
-		];
-
 		return (
 			<div>
 				<span style={{ marginBottom: 5, fontSize: 12 }}>多选：</span>
@@ -234,7 +240,7 @@ export default class TreeSelectDemo extends React.Component {
 					allowClear
 					style={{ marginBottom: 20 }}
 					placeholder="选择一个选项"
-					dataSource={treeData}
+					dataSource={this.treeData}
 					dropdownStyle={{ color: 'red' }}
 					dropdownClassName="test"
 					value={this.state.selectedNodes}
@@ -248,7 +254,7 @@ export default class TreeSelectDemo extends React.Component {
 					placeholder="选择一个选项"
 					style={{ marginBottom: 20 }}
 					footerTypes={['ok', 'reset']}
-					dataSource={treeData}
+					dataSource={this.treeData}
 					showIcon={false}
 					value={this.state.confirmNodes}
 					onChange={this.handleChange}
@@ -260,7 +266,7 @@ export default class TreeSelectDemo extends React.Component {
 					isUnfold
 					containParentNode
 					placeholder="选择一个选项"
-					dataSource={treeData}
+					dataSource={this.treeData}
 					value={this.state.singleNodes}
 					onChange={this.onChangeSingle}
 				/>

--- a/src/components/tree-select/index.less
+++ b/src/components/tree-select/index.less
@@ -253,7 +253,7 @@
 	}
 
 	.@{prefix}-tree {
-		padding: 5px 13px;
+		padding: 5px 0;
 		overflow: auto;
 	}
 }

--- a/src/components/tree/demos/defineStyle.markdown
+++ b/src/components/tree/demos/defineStyle.markdown
@@ -97,7 +97,7 @@ export default class TreeDemo extends React.Component {
 			color: 'red'
 		};
 
-		return <Tree treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
+		return <Tree supportMenu isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
 	}
 }
 ```
@@ -107,5 +107,6 @@ export default class TreeDemo extends React.Component {
 	background: #d7e7f3;
 	width: 200px;
 	overflow: auto;
+	height: 300px;
 }
 ```

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import ShuyunUtils from 'shuyun-utils';
 import { noop, prefixCls } from '@utils';
 import TreeContext from './context';
@@ -94,7 +95,7 @@ class Tree extends Component {
 				selectedValue: nextProps.selectedValue,
 				preSelectedNode: nextProps.selectedValue && nextProps.selectedValue[0],
 				prevProps: nextProps,
-				treeData: store.initData(nextProps.treeData, prevProps.maxLevel, nextProps.selectedValue, prevProps.isUnfold)
+				treeData: store.initData(prevState.treeData, prevProps.maxLevel, nextProps.selectedValue)
 			};
 		}
 
@@ -415,7 +416,11 @@ class Tree extends Component {
 						onEditNodeBefore={onReRenderNode}
 					/>
 
-					{treeData && treeData.length > 0 && <TreeList prefixCls={selector} nodeNameMaxLength={nodeNameMaxLength} data={treeData} />}
+					{treeData && treeData.length > 0 && (
+						<div className={classNames(`${selector}-list-container`)}>
+							<TreeList prefixCls={selector} nodeNameMaxLength={nodeNameMaxLength} data={treeData} />
+						</div>
+					)}
 
 					{(!treeData || !treeData.length) && <p>暂无结果</p>}
 				</div>

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -62,7 +62,6 @@
 
 			.node-item {
 				display: inline-flex;
-				width: 100%;
 				height: 26px;
 				border-radius: 2px;
 				line-height: 26px;
@@ -87,6 +86,7 @@
 			}
 
 			.node-input {
+				width: 152px;
 				height: 26px;
 				margin-right: 4px;
 			}
@@ -113,6 +113,10 @@
 				color: #36cb37;
 			}
 
+			.cancel-icon {
+				width: 28px;
+			}
+
 			.is-active:not(.support-checkbox) {
 				background: @selector-node-active-background;
 			}
@@ -121,7 +125,7 @@
 		.child-style .node-item-container {
 			.node-item,
 			.is-rename {
-				margin-left: 16px;
+				margin-left: 14px;
 			}
 		}
 

--- a/src/components/tree/menu.js
+++ b/src/components/tree/menu.js
@@ -18,6 +18,8 @@ class TreeMenu extends Component {
 		options.setInputValue('');
 		this.props.onEditNodeBefore({ preNode: this.preNode, currentNode: node, isAdd: true, isUnfold: true });
 		this.preNode = node;
+
+		this.scrollIntoView();
 	};
 
 	deleteNode = e => {
@@ -38,6 +40,17 @@ class TreeMenu extends Component {
 		options.setInputValue(name);
 		this.props.onEditNodeBefore({ preNode: this.preNode, currentNode: node, isEdit: true });
 		this.preNode = node;
+
+		this.scrollIntoView();
+	};
+
+	scrollIntoView = () => {
+		setTimeout(() => {
+			const ele = document.querySelector('.cloud-tree .cancel-icon');
+			if (ele) {
+				ele.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+			}
+		});
 	};
 
 	render() {

--- a/src/components/tree/node.js
+++ b/src/components/tree/node.js
@@ -51,7 +51,8 @@ class Node extends Component {
 	};
 
 	// 保存节点信息
-	onSaveClick = (data, name) => {
+	onSaveClick = (e, data, name) => {
+		e.stopPropagation();
 		const { id, level } = data;
 		// 输入内容不能为空
 		if (!this.state.inputValue) {
@@ -75,7 +76,8 @@ class Node extends Component {
 	};
 
 	// 取消保存
-	onClickCancel = data => {
+	onClickCancel = (e, data) => {
+		e.stopPropagation();
 		this.setState({
 			inputValue: ''
 		});
@@ -96,7 +98,8 @@ class Node extends Component {
 		const { setInputValue, onSaveClick, onClickCancel } = this;
 		// 将三个方法传递出去可以供外部调用
 		const options = { setInputValue, onSaveClick, onClickCancel };
-		const paddingLeft = 16 * data.level;
+		const paddingLeft = 14 * data.level;
+
 		return (
 			<Fragment>
 				<div className={classNames(`${prefixCls}-list-node-area ${data.children && !data.children.length ? 'child-style' : null}`)}>
@@ -107,7 +110,9 @@ class Node extends Component {
 						className={`node-item-container ${data.isActive ? 'is-active' : null} ${this.context.supportCheckbox ? 'support-checkbox' : ''}`}>
 						{/* 折叠展开icon */}
 						<ToggleFold hasChildren={data.children.length > 0} showChildrenItem={data.isUnfold} toggle={e => this.toggle(e, data)} />
-						<div className={`node-item ${data.isEdit && !data.isAdd ? 'hide-node' : null}`}>
+						<div
+							style={{ width: `calc(100% - ${paddingLeft}px - 8px)` }}
+							className={`node-item ${data.isEdit && !data.isAdd ? 'hide-node' : null}`}>
 							{/* 节点前面的icon */}
 							<NodeIcon
 								showIcon={this.context.showIcon}
@@ -137,8 +142,8 @@ class Node extends Component {
 							inputValue={this.state.inputValue}
 							maxLength={this.context.nodeNameMaxLength}
 							handleInputChange={this.handleInputChange}
-							saveItem={() => this.onSaveClick(data, this.state.inputValue)}
-							cancelSave={() => this.onClickCancel(data)}
+							saveItem={e => this.onSaveClick(e, data, this.state.inputValue)}
+							cancelSave={e => this.onClickCancel(e, data)}
 						/>
 					</div>
 					{data.isUnfold && <ul>{children}</ul>}

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -25,7 +25,7 @@ class Store {
 		// 处理已选中的节点，treeData中存在selectedValue中的值则选中
 		const cloneData = this.onResetData(ShuyunUtils.clone(treeData));
 
-		// 单选则直接选中回显值，多选则默认第一个
+		// 选中回显值
 		const activeNode = selectedValue && selectedValue[0];
 		if (activeNode) {
 			this.updateNodeById(cloneData, activeNode.id, { isActive: true });
@@ -67,18 +67,23 @@ class Store {
 			// 增加层级
 			tmp.level = level;
 			// 增加是否展开标志
-			tmp.isUnfold = isUnfold;
+			if (isUnfold !== undefined) {
+				tmp.isUnfold = isUnfold;
+			}
 
 			// 寻找父节点
 			const pNode = this.findNodeById(cloneData, tmp.pId);
 			// 无父节点则为根节点，默认展开
-			if (!pNode) {
+			if (!pNode && isUnfold !== undefined) {
 				tmp.isUnfold = true;
 			}
 
 			// 存在已选中节点，则根节点半选
 			if (selectedValue && selectedValue.length && !pNode) {
-				tmp.indeterminate = true;
+				// 特殊情况处理——有多个根节点
+				if (selectedValue.find(item => this.findNodeById([tmp], item.id))) {
+					tmp.indeterminate = true;
+				}
 			}
 
 			if (!children) {


### PR DESCRIPTION
 这个变动的性质是？
-   [ ] 新功能提交
-   [X] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案
1. Tree：当横向出现滚动条，选中目录后，背景色区域右侧留白过多；
2. Tree：当横向出现滚动条，hover不同层级的目录，背景色宽度不一样
3. Tree：右键新增或者编辑的时候，输入框自动滚动到可视区域（线上问题）
4. Tree：点击保存和取消按钮的时候，阻止事件冒泡；
5. Tree：调整不同层级的缩进和一个字的大小相等，否则带有子节点和不带子节点目录会对不齐，大约会差2px；
6. Tree：存在多个根节点的情况处理（涉及多选Tree相关逻辑）
7. Tree：监听外部回显数据变化的时候，传入的 treeData 应为 state 中保存的数据，而不是从 pros 中拿的原数据（造成的问题：在多选下拉组件中使用的时候，如果把tree展开或者折叠后再选中，状态会恢复成原始状态）
