### PR TITLE
[Form] 新增表单提交失败时可让失败的第一个表单项滚动至可视区域特性

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -148,18 +148,19 @@ export default class Field {
 		return null;
 	};
 
-	getErrors = names => {
-		if (!names || !Array.isArray(names)) {
-			return [];
+	getErrors = (names = Object.keys(this.fieldsMeta)) => {
+		if (!names) {
+			return {};
 		}
 
-		const errors = {};
+		return names.reduce((acc, name) => {
+			const err = this.getError(name);
 
-		names.forEach(name => {
-			errors[name] = this.getError(name);
-		});
-
-		return errors;
+			if (err) {
+				acc[name] = err;
+			}
+			return acc;
+		}, {});
 	};
 
 	setError = (name, errors) => {

--- a/src/components/form/constants.js
+++ b/src/components/form/constants.js
@@ -44,3 +44,13 @@ export const findDestroyedFields = (prevNames, names) => {
 		return acc;
 	}, []);
 };
+
+export const getParentFormClassName = (ele, className) => {
+	if (!ele) return null;
+
+	if (ele.classList.contains(className)) {
+		return ele;
+	}
+
+	return getParentFormClassName(ele.parentNode, className);
+};

--- a/src/components/form/demos/basic-usage.markdown
+++ b/src/components/form/demos/basic-usage.markdown
@@ -31,7 +31,7 @@ export default class FormBasicDemo extends React.Component {
 		const { init } = this.field;
 
 		return (
-			<Form field={this.field} onSubmit={this.onSubmit.bind(this)} labelCol={{ offset: 6 }} wrapperCol={{ offset: 6 }}>
+			<Form field={this.field} onSubmit={this.onSubmit.bind(this)} labelCol={{ offset: 6 }} wrapperCol={{ offset: 6 }} scrollToFirstError>
 				<Form.Item label="用户名" help="额外的提示信息">
 					<Input
 						style={{ width: '70%' }}

--- a/src/components/form/index.js
+++ b/src/components/form/index.js
@@ -1,17 +1,23 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import omit from '@utils/omit';
 
-import { prefixCls } from '@utils';
-
+import { prefixCls } from '@utils/config';
+import Modal from '../modal';
 import FormItem from './form-item';
 import Nexus from './form-nexus';
 import FormContext from './context';
-import { LAYOUT_TYPES, LABEL_ALIGN } from './constants';
+import { LAYOUT_TYPES, LABEL_ALIGN, getParentFormClassName } from './constants';
 
 import './index.less';
 
+const ERROR_SELECTOR = `.${prefixCls}-form-item-explain.error`;
+const FORM_ITEM_SELECTOR = `${prefixCls}-form-item`;
+
 export default class Form extends Component {
+	static contextType = Modal.ConfigProvider;
+
 	static propTypes = {
 		field: PropTypes.object,
 		colon: PropTypes.bool,
@@ -26,6 +32,7 @@ export default class Form extends Component {
 			span: PropTypes.number,
 			offset: PropTypes.number
 		}),
+		scrollToFirstError: PropTypes.bool,
 		children: PropTypes.any
 	};
 
@@ -37,20 +44,49 @@ export default class Form extends Component {
 		field: {},
 		labelCol: {},
 		wrapperCol: {},
-		children: null
+		children: null,
+		scrollToFirstError: false
 	};
 
 	static Item = FormItem;
 
 	static Nexus = Nexus;
 
+	get document() {
+		return this.context.rootDocument || document;
+	}
+
+	componentDidUpdate() {
+		const { field, scrollToFirstError } = this.props;
+
+		if (!field.getErrors || !scrollToFirstError) {
+			return;
+		}
+
+		const firstErrNode = this.document.querySelector(ERROR_SELECTOR);
+		const formItemNode = getParentFormClassName(firstErrNode, FORM_ITEM_SELECTOR);
+		const errors = field.getErrors();
+
+		// 没有表单项出现错误，不处理
+		if (Object.keys(errors).length === 0 || !firstErrNode || !formItemNode) {
+			return;
+		}
+
+		// 当第一个失败的表单项不在可视区域时则滚动到可视区域
+		formItemNode.scrollIntoView({
+			behavior: 'smooth',
+			block: 'nearest'
+		});
+	}
+
 	render() {
 		const { children, colon, field, layout, labelCol, wrapperCol, labelAlign, className, ...others } = this.props;
+		const props = omit(others, ['scrollToFirstError']);
 		const classNames = classnames(`${prefixCls}-form`, className);
 
 		return (
 			<FormContext.Provider value={{ colon, field, layout, labelAlign, labelCol, wrapperCol }}>
-				<form {...others} className={classNames}>
+				<form {...props} className={classNames}>
 					{children}
 				</form>
 			</FormContext.Provider>

--- a/src/components/form/index.md
+++ b/src/components/form/index.md
@@ -22,6 +22,7 @@ subtitle: 表单
 | onSubmit   | form 内有`htmlType="submit"`的元素的时候会触发                        | Function(evt:Event) | -          |
 | colon      | 配合`label`属性使用，表示是否显示`label`后面的冒号                    | boolean             | `true`     |
 | className  | Form 的 className 属性                                                | string              | -          |
+| scrollToFirstError | 提交失败自动滚动到第一个错误字段，`field`字段不存在时无效			| boolean              | `false`     |
 
 如果 Form 和 Form.Item 相同的属性，Form.Item 的优先级更高，如果 Form 上设置了就不用每一个 Form.Item 上都进行设置，更加方便
 


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [x] 新功能提交

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 表单容器较小时，失败的表单项如果不在可视区域，可将其滚动至可视区域
2. `Form`组件新增`scrollToFirstError`字段，值为`true/false`默认为`false`

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1. `Form`组件新增表单校验失败时可将不在可视区域的第一条失败的内容展示到可视区域内，使用`scrollToFirstError`字段来选择是否开启

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
