### PR TITLE
[Modal]修复弹框组件在iframe场景下基础组件不在隔离容器内问题

### DIFF
--- a/src/components/datepicker/common/picker.js
+++ b/src/components/datepicker/common/picker.js
@@ -70,6 +70,11 @@ class Picker extends Component {
 		return this.context.rootDocument;
 	}
 
+	get portal() {
+		const { getContext } = this.context;
+		return getContext() || this.document.body;
+	}
+
 	handleValueChange = (output = '', isPop = false) => {
 		const value = this.props.formatValue(output);
 		this.setState({
@@ -256,7 +261,7 @@ class Picker extends Component {
 						<div className={`${selectorClass}-popup ${className}`} ref={this.popupRef} style={{ ...style }} onClick={this.popClick}>
 							{this.renderMainPop()}
 						</div>,
-						this.document.body
+						this.portal
 					)}
 			</div>
 		);

--- a/src/components/modal/config-provider.js
+++ b/src/components/modal/config-provider.js
@@ -1,6 +1,10 @@
 import { createContext } from 'react';
+import { sandboxSelector } from './constants';
 
 export default createContext({
 	rootWindow: window,
-	rootDocument: document
+	rootDocument: document,
+	getContext() {
+		return document.querySelector(`.${sandboxSelector}`) || document.body;
+	}
 });

--- a/src/components/modal/constants.js
+++ b/src/components/modal/constants.js
@@ -1,0 +1,3 @@
+export const sandboxSelector = 'r-w_s-';
+
+export default {};

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import { getRootWindow } from '@utils';
+import { sandboxSelector } from './constants';
 import './index.less';
 import Notification from './modal';
 import Prompt from './prompt';
@@ -25,7 +26,12 @@ class Modal extends Component {
 		const rootDocument = rootWindow.document;
 
 		return ReactDOM.createPortal(
-			<Context.Provider value={{ rootWindow, rootDocument }}>
+			<Context.Provider
+				value={{
+					rootWindow,
+					rootDocument,
+					getContext: () => rootDocument.querySelector(`.${sandboxSelector}`) || rootDocument.body
+				}}>
 				<Notification type="modal" {...props}>
 					{children}
 				</Notification>

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -2,25 +2,23 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { prefixCls, getCssText } from '@utils';
+import { sandboxSelector } from './constants';
 import Icon from '../icon';
 import Button from '../button';
 import ModalConfigContext from './config-provider';
 import './index.less';
 
-// 尽可能节省字节
-const rootWrapSelector = 'r-w_s-';
-
-// 获取当前document下的所有样式创建到顶层doucment上，rootWrapSelector是一个简单的隔离方式
+// 获取当前document下的所有样式创建到顶层doucment上，sandboxSelector是一个简单的隔离方式
 function insertRootDocumentStyleRule(doc) {
-	let style = doc.querySelector(`[data-name="${rootWrapSelector}"]`);
+	let style = doc.querySelector(`[data-name="${sandboxSelector}"]`);
 
 	if (style) return;
 
-	const cssText = getCssText(`.${rootWrapSelector}`);
+	const cssText = getCssText(`.${sandboxSelector}`);
 
 	style = document.createElement('style');
 
-	style.setAttribute('data-name', rootWrapSelector);
+	style.setAttribute('data-name', sandboxSelector);
 	style.setAttribute('type', 'text/css');
 
 	style.innerHTML = cssText.join('');
@@ -284,7 +282,7 @@ class Notification extends Component {
 
 		// 不要删除最外层的节点，虽然看似多余，但在iframe场景下至关重要
 		return (
-			<div className={rootWrapSelector}>
+			<div className={sandboxSelector}>
 				<div
 					id="mask"
 					ref={this.maskRef}

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -123,6 +123,11 @@ class Select extends Component {
 		return this.context.rootDocument;
 	}
 
+	get portal() {
+		const { getContext } = this.context;
+		return getContext() || this.document.body;
+	}
+
 	get defaultSelectValue() {
 		const { value, defaultValue, multiple } = this.props;
 		if (multiple) {
@@ -380,7 +385,7 @@ class Select extends Component {
 		const { width } = this.selectedContainerStyle;
 		const classNames = classnames(`${selector}`, { [`${selector}-open`]: open }, className);
 
-		const containerEle = isAppendToBody ? this.document.body : this.node.current;
+		const containerEle = isAppendToBody ? this.portal : this.node.current;
 
 		return (
 			<div className={`${classNames}`} style={style} ref={this.node}>

--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -48,8 +48,12 @@ class Tooltip extends Component {
 	}
 
 	get document() {
-		// 使用 || 来兼容未合并相关代码的情况
-		return this.context.rootDocument || document;
+		return this.context.rootDocument;
+	}
+
+	get portal() {
+		const { getContext } = this.context;
+		return getContext() || this.document.body;
 	}
 
 	getChildren() {
@@ -102,7 +106,7 @@ class Tooltip extends Component {
 					target
 				}}
 			/>,
-			this.document.body
+			this.portal
 		);
 	}
 


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？


-   [x] 日常 bug 修复

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. iframe场景下Modal组件创建到顶层文档时会创建隔离容器，但其他普通组件直接创建到body了，样式有可能会存在丢失
2. Modal.ConfigProvider 提供 getContext方法可获取隔离容器

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1. 修复Modal组件在iframe场景下内容可能会出现样式丢失问题

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
