### PR TITLE
[Tooltip]修复content值渲染方式异常问题

### DIFF
--- a/src/components/tooltip/toolView.js
+++ b/src/components/tooltip/toolView.js
@@ -1,4 +1,4 @@
-import React, { Component, isValidElement } from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import { prefixCls } from '@utils';
 import { CONFIG_PLACE } from './config';
@@ -154,10 +154,10 @@ export default class ToolView extends Component {
 		};
 
 		// 检测到非React节点时，使用html到方式插入
-		if (isValidElement(content)) {
-			return <div {...props}>{content}</div>;
+		if (typeof content !== 'object') {
+			return <div {...props} dangerouslySetInnerHTML={{ __html: content }} />;
 		}
 
-		return <div {...props} dangerouslySetInnerHTML={{ __html: content }} />;
+		return <div {...props}>{content}</div>;
 	}
 }


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [x] 日常 bug 修复

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. Tooltip组件content属性的值为数组类型的JSX时，渲染错误问题
2. 修改ReactNode和HTML格式判断逻辑

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1. 修复Tooltip组件content属性渲染数组结构JSX节点异常bug

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
