### PR TITLE
[Message]修复组件获取rootWindow时机不对问题

### DIFF
--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -7,9 +7,7 @@ import Icon from '../icon';
 
 import './index.less';
 
-const rootDocument = getRootWindow().document;
-
-const DEFAULTOPTS = { duration: 3000, contextContainer: rootDocument.body };
+const DEFAULT_OPTS = { duration: 3000, contextContainer: document.body };
 
 const MESSAGE_TYPE = {
 	success: {
@@ -34,7 +32,16 @@ function removeWraper(contextContainer) {
 function entity(config) {
 	const { type, msg, options } = config;
 
-	const opts = Object.assign({}, DEFAULTOPTS, options);
+	const rootDocument = getRootWindow().document;
+	const opts = Object.assign(
+		{},
+		DEFAULT_OPTS,
+		{
+			contextContainer: rootDocument.body
+		},
+		options
+	);
+
 	const props = {
 		type,
 		msg,
@@ -62,6 +69,8 @@ function entity(config) {
 	const container = rootDocument.createElement('div');
 
 	wraper.appendChild(container);
+
+	console.log(contextContainer);
 
 	contextContainer.appendChild(wraper);
 


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [x] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. `Message`组件在`iframe`嵌套场景下偶尔获取不到顶层`window`全局对象
2. 通过排查是获取时机不对，之前是在初始化时就进行获取了，目前改成使用时再获取

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
修复`Message`组件获取顶层`window`全局对象时机不正确bug

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
