### PR TITLE
[Tree]增加拖拽功能,增加弹框形式菜单,增加双击事件

### DIFF
--- a/src/components/tree/demos/defineIcon.markdown
+++ b/src/components/tree/demos/defineIcon.markdown
@@ -102,6 +102,7 @@ export default class TreeDemo extends React.Component {
 				openIconType={this.state.openIconType}
 				closeIconType={this.state.closeIconType}
 				iconColor={this.state.iconColor}
+				showIcon
 				onSelectedNode={this.selectedNode}
 			/>
 		);

--- a/src/components/tree/demos/defineStyle.markdown
+++ b/src/components/tree/demos/defineStyle.markdown
@@ -38,7 +38,7 @@ export default class TreeDemo extends React.Component {
 						children: [
 							{
 								id: 111,
-								name: '这里将会是一个超级超级长的节点，这个节点名称也会超级超级长，毕竟是为了测试极端情况下的样式问题',
+								name: '123456789101112312423423',
 								pId: 11,
 								categoryType: 0
 							}
@@ -94,18 +94,17 @@ export default class TreeDemo extends React.Component {
 			}
 		];
 		const style = {
-			color: 'red'
+			color: '#333'
 		};
 
-		return <Tree supportMenu isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
+		return <Tree supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
 	}
 }
 ```
 
 ```less
 .bg {
-	background: #d7e7f3;
-	width: 200px;
+	width: 220px;
 	overflow: auto;
 	height: 300px;
 }

--- a/src/components/tree/demos/drag.markdown
+++ b/src/components/tree/demos/drag.markdown
@@ -1,0 +1,225 @@
+---
+order: 11
+title: 拖拽用法
+desc: 支持拖拽同级节点进行位置互换
+---
+
+```javascript
+import React from 'react';
+import { Tree } from 'cloud-react';
+
+export default class TreeDemo extends React.Component {
+	selectedNode = node => {
+		console.info('已选择一个节点，节点信息是：');
+		console.log(node);
+	};
+
+    onDragBefore = (node) => {
+        console.log('将要移动的节点: ', node);
+    }
+
+    onDragMoving = (node, aimNode) => {
+        // console.log('正在移动的节点: ', node);
+        // console.log('目标节点: ', aimNode);
+    }
+
+    onDragAfter = (node, aimNode, pNode) => {
+        console.log('最终替换的节点: ', node);
+        console.log('最终被替换的节点: ', aimNode);
+        console.log('父节点: ', pNode);
+    }
+
+	render() {
+		const treeData = [
+			{
+				id: 1,
+				name: '所有1',
+				pId: null,
+				disableRemove: true,
+				disableRename: true,
+				children: [
+					{
+						id: 11,
+						name: '禁止删除节点11',
+						pId: 1,
+						disableRemove: true,
+						children: [
+							{
+								id: 111,
+								name: '删除一个111',
+								pId: 11,
+								children: []
+							},
+							{
+								id: 112,
+								name: '删除两个112',
+								pId: 11,
+								children: []
+							},
+							{
+								id: 113,
+								name: '删除三个113',
+								pId: 11,
+								children: [
+									{
+										id: 1131,
+										name: '禁止删除节点1131',
+										pId: 113,
+										children: []
+									},
+									{
+										id: 1132,
+										name: '禁止删除节点1132',
+										pId: 113
+									},
+                                    {
+										id: 1133,
+										name: '禁止删除节点1133',
+										pId: 113,
+										children: []
+									},
+                                    {
+										id: 1134,
+										name: '禁止删除节点1134',
+										pId: 113,
+										children: []
+									},
+                                    {
+										id: 1135,
+										name: '禁止删除节点1135',
+										pId: 113,
+										children: []
+									},
+								]
+							},
+							{
+								id: 114,
+								name: '禁止删除节点114',
+								pId: 11,
+								children: []
+							}
+						]
+					},
+					{
+						id: 12,
+						name: '禁止新增节点12',
+						pId: 1,
+						disableAdd: true,
+						children: [
+							{
+								id: 121,
+								name: '禁止新增节点121',
+								pId: 12,
+								children: [
+									{
+										id: 1211,
+										name: '禁止新增节点1211',
+										pId: 121,
+										children: []
+									},
+									{
+										id: 1212,
+										name: '禁止新增节点1212',
+										pId: 121,
+										children: []
+									},
+									{
+										id: 1213,
+										name: '禁止新增节点1213',
+										pId: 121,
+										children: []
+									}
+								]
+							},
+							{
+								id: 122,
+								name: '禁止新增节点122',
+								pId: 12,
+								children: [
+									{
+										id: 1221,
+										name: '禁止新增节点1221',
+										pId: 122,
+										children: []
+									},
+									{
+										id: 1222,
+										name: '禁止新增节点1222',
+										pId: 122,
+										children: []
+									}
+								]
+							}
+						]
+					},
+					{
+						id: 13,
+						name: '禁止重命名节点13',
+						pId: 1,
+						disableRename: true,
+						children: [
+							{
+								id: 131,
+								name: '禁止重命名节点131',
+								pId: 13,
+								children: [
+									{
+										id: 1311,
+										name: '禁止重命名节点1311',
+										pId: 131,
+										children: []
+									},
+									{
+										id: 1312,
+										name: '禁止重命名节点1312',
+										pId: 131,
+										children: []
+									},
+									{
+										id: 1313,
+										name: '禁止重命名节点1313',
+										pId: 131,
+										children: []
+									}
+								]
+							},
+							{
+								id: 132,
+								name: '禁止重命名节点132',
+								pId: 13,
+								children: [
+									{
+										id: 1321,
+										name: '禁止重命名节点1321',
+										pId: 132,
+										children: []
+									}
+								]
+							}
+						]
+					},
+					{
+						id: 14,
+						name: '未分类14',
+						pId: 1,
+						disableRemove: true,
+						disableAdd: true,
+						disableRename: true,
+						children: []
+					}
+				]
+			}
+		];
+		return (
+			<Tree
+				treeData={treeData}
+				isUnfold
+                supportDrag
+                onDragBefore={this.onDragBefore}
+                onDragMoving={this.onDragMoving}
+                onDragAfter={this.onDragAfter}
+				onSelectedNode={this.selectedNode}/>
+		);
+	}
+}
+```

--- a/src/components/tree/demos/menuDialog.markdown
+++ b/src/components/tree/demos/menuDialog.markdown
@@ -1,12 +1,12 @@
 ---
-order: 1
-title: 基础用法
-desc: 支持搜索节点、右键菜单、最大层级为4、节点名称最大长度20、可搜索关键字长度最大为20个字符、新增节点加到当前节点的子节点末尾，展开全部节点
+order: 12
+title: 弹框菜单
+desc: 支持使用弹框类型打开菜单
 ---
 
 ```javascript
 import React from 'react';
-import { Tree, Modal } from 'cloud-react';
+import { Tree } from 'cloud-react';
 
 export default class TreeDemo extends React.Component {
 	constructor(props) {
@@ -15,11 +15,8 @@ export default class TreeDemo extends React.Component {
 		this.state = {
 			searchPlaceholder: '这是最基础的树组件',
 			searchMaxLength: 20,
-			nodeNameMaxLength: 20,
-			maxLevel: 4,
-			supportMenu: true,
-			supportSearch: true,
-			isAddFront: false
+			nodeNameMaxLength: 50,
+			maxLevel: 4
 		};
 	}
 
@@ -51,15 +48,6 @@ export default class TreeDemo extends React.Component {
 		console.info('已选择一个节点，节点信息是：');
 		console.log(node);
 	};
-
-    onDoubleClick = node => {
-        Modal.confirm({
-            body: 'hello, 你双击了我，我会给你我的信息，请点击确定后在控制台查看',
-            onOk: () => {
-                console.log(node);
-            }
-        })
-    };
 
 	render() {
 		const treeData = [
@@ -239,15 +227,14 @@ export default class TreeDemo extends React.Component {
 				searchMaxLength={this.state.searchMaxLength}
 				nodeNameMaxLength={this.state.nodeNameMaxLength}
 				maxLevel={this.state.maxLevel}
-				isUnfold={true}
-				supportMenu={this.state.supportMenu}
-				supportSearch={this.state.supportSearch}
-				isAddFront={this.state.isAddFront}
+				supportMenu
+                isUnfold
+                menuType="dialogMenu"
+                addMenuName="分类"
 				onAddNode={this.addNode}
-				onDoubleClick={this.onDoubleClick}
 				onRenameNode={this.renameNode}
 				onRemoveNode={this.removeNode}
-				onSelectedNode={this.selectedNode}></Tree>
+				onSelectedNode={this.selectedNode}/>
 		);
 	}
 }

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -7,15 +7,29 @@ import TreeContext from './context';
 import Search from './search';
 import TreeList from './list';
 import Message from '../message';
+import Input from '../input';
 import Modal from '../modal';
 import Store from './store';
 import Menu from './menu';
 import './index.less';
 
+// 默认菜单类型，右键打开
+const MENU_TYPE = 'rightMenu';
 const store = new Store();
+// 菜单弹框样式
+const menuModalStyle = {
+	width: 450,
+	height: 240,
+	minHeight: 240
+};
+const menuModalBodyStyle = {
+	height: 106,
+	maxHeight: 106,
+	padding: '23px 30px'
+};
 
 class Tree extends Component {
-	// 默认值， 默认类型与值不匹配
+	// 默认值
 	static defaultProps = {
 		style: {},
 		className: '',
@@ -30,15 +44,23 @@ class Tree extends Component {
 		iconColor: '#999',
 		supportCheckbox: false,
 		supportMenu: false,
+		isShowNameTooltip: false,
+		menuType: MENU_TYPE,
+		addMenuName: '子目录',
 		supportSearch: false,
+		supportDrag: false,
 		supportImmediatelySearch: false,
 		isAddFront: true,
 		selectedValue: [],
+		onDoubleClick: noop,
 		onAddNode: noop,
 		onRenameNode: noop,
 		onRemoveNode: noop,
 		onSelectedNode: noop,
-		onSearchResult: noop
+		onSearchResult: noop,
+		onDragMoving: noop,
+		onDragBefore: noop,
+		onDragAfter: noop
 	};
 
 	static propsTypes = {
@@ -56,15 +78,23 @@ class Tree extends Component {
 		iconColor: PropTypes.string,
 		supportCheckbox: PropTypes.bool,
 		supportMenu: PropTypes.bool,
+		isShowNameTooltip: PropTypes.bool,
+		menuType: PropTypes.string,
+		addMenuName: PropTypes.string,
 		supportSearch: PropTypes.bool,
+		supportDrag: PropTypes.bool,
 		supportImmediatelySearch: PropTypes.bool,
 		isAddFront: PropTypes.bool,
 		selectedValue: PropTypes.array,
+		onDoubleClick: PropTypes.func,
 		onAddNode: PropTypes.func,
 		onRenameNode: PropTypes.func,
 		onRemoveNode: PropTypes.func,
 		onSelectedNode: PropTypes.func,
-		onSearchResult: PropTypes.func
+		onSearchResult: PropTypes.func,
+		onDragMoving: PropTypes.func,
+		onDragBefore: PropTypes.func,
+		onDragAfter: PropTypes.func
 	};
 
 	constructor(props) {
@@ -74,8 +104,11 @@ class Tree extends Component {
 		const treeData = store.initData(props.treeData, props.maxLevel, props.selectedValue, props.isUnfold);
 
 		this.state = {
-			visibleMenu: false,
+			showRightMenu: false,
+			showDialogMenu: false,
 			nodeData: {},
+			isAddMenuOpen: false,
+			parentNodeNames: {},
 			menuStyle: null,
 			menuOptions: null,
 			searchText: '',
@@ -103,13 +136,13 @@ class Tree extends Component {
 	}
 
 	componentDidMount() {
-		document.addEventListener('click', this.hideMenu);
-		document.addEventListener('scroll', this.hideMenu, true);
+		document.addEventListener('scroll', this.onHideMenu, true);
+		document.addEventListener('click', this.onHideMenu);
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener('click', this.hideMenu);
-		document.removeEventListener('scroll', this.hideMenu, true);
+		document.removeEventListener('click', this.onHideMenu);
+		document.removeEventListener('scroll', this.onHideMenu, true);
 	}
 
 	/**
@@ -119,7 +152,8 @@ class Tree extends Component {
 	 */
 	updateActiveNode = (data, node) => {
 		store.updateNodeById(data, node.id, { isActive: true });
-		if (this.state.preSelectedNode) {
+		// 点击同个节点则状态不变
+		if (this.state.preSelectedNode && this.state.preSelectedNode.id !== node.id) {
 			store.updateNodeById(data, this.state.preSelectedNode.id, { isActive: false });
 		}
 	};
@@ -156,6 +190,7 @@ class Tree extends Component {
 	 * @param node
 	 */
 	onSelectedAction = node => {
+		this.onHideMenu();
 		const data = this.state.treeData;
 		const { supportCheckbox, onSelectedNode } = this.props;
 
@@ -166,6 +201,7 @@ class Tree extends Component {
 		// 多选节点列表
 		const checkboxSelectedList = this.getSelectedMoreList(data, node);
 
+		// 选中结果
 		const selectedResult = supportCheckbox ? checkboxSelectedList : radioSelectedList;
 
 		// 传递到外部
@@ -173,9 +209,9 @@ class Tree extends Component {
 
 		// 更新树列表数据
 		this.setState({
-			treeData: ShuyunUtils.clone(data)
+			treeData: ShuyunUtils.clone(data),
+			preSelectedNode: node
 		});
-		this.setState({ preSelectedNode: node });
 	};
 
 	/**
@@ -217,7 +253,7 @@ class Tree extends Component {
 	};
 
 	/**
-	 * 新增节点
+	 * 新增节点保存
 	 * @param pId
 	 * @param value
 	 * @param pLevel
@@ -229,12 +265,13 @@ class Tree extends Component {
 				const newNode = { id: res.data || res.id, name: value, children: [], pId, level: pLevel + 1, disableAdd: maxLevel - pLevel === 1 };
 				const treeData = store.addChildNode(this.state.treeData, pId, newNode, isAddFront);
 				const allTreeData = store.addChildNode(this.state.allTreeData, pId, newNode, isAddFront);
-				// 新增之后重新init判断层级，不然会出现无层级可继续添加问题
 				this.setState({
 					treeData: ShuyunUtils.clone(treeData),
 					allTreeData: ShuyunUtils.clone(allTreeData)
 				});
 				Message.success('添加成功');
+				// 关闭弹框
+				this.onHideMenuDialog();
 			})
 			.catch(() => {
 				Message.error('添加失败');
@@ -242,7 +279,7 @@ class Tree extends Component {
 	};
 
 	/**
-	 * 重命名节点
+	 * 重命名节点保存
 	 * @param id
 	 * @param newValue
 	 */
@@ -257,6 +294,8 @@ class Tree extends Component {
 					allTreeData: ShuyunUtils.clone(allTreeData)
 				});
 				Message.success('更新成功');
+				// 关闭弹框
+				this.onHideMenuDialog();
 			})
 			.catch(() => {
 				Message.error('更新失败');
@@ -265,10 +304,11 @@ class Tree extends Component {
 
 	/**
 	 * 名称重复校验
+	 * @param node
 	 * @param name
 	 */
-	onCheckRepeatNameAction = name => {
-		return store.checkRepeatName(this.state.treeData, name);
+	onCheckRepeatNameAction = (node, name) => {
+		return store.checkRepeatName(this.state.treeData, node, name);
 	};
 
 	/**
@@ -277,17 +317,23 @@ class Tree extends Component {
 	 */
 	onRemoveAction = node => {
 		const { onRemoveNode } = this.props;
+		this.onHideMenu();
 		Modal.confirm({
 			isShowIcon: false,
 			body: '你确定删除此目录吗?',
 			onOk: () => {
+				const { treeData } = this.state;
+				if (!store.removeChildNode(treeData, node)) {
+					Message.error('该目录存在子目录，不可删除!');
+					return;
+				}
 				onRemoveNode(node.id, node)
 					.then(() => {
-						const treeData = store.removeChildNode(this.state.treeData, node);
-						const allTreeData = store.removeChildNode(this.state.allTreeData, node, false);
+						store.removeChildNode(treeData, node);
+						// const allTreeData = store.removeChildNode(this.state.allTreeData, node);
 						this.setState({
-							treeData: ShuyunUtils.clone(treeData),
-							allTreeData: ShuyunUtils.clone(allTreeData)
+							treeData,
+							allTreeData: ShuyunUtils.clone(treeData)
 						});
 					})
 					.catch(() => {
@@ -300,12 +346,24 @@ class Tree extends Component {
 
 	onReRenderNode = ({ preNode, currentNode, isEdit = false, isAdd = false, isUnfold }) => {
 		const { treeData } = this.state;
-		const pre = store.findNodeById(treeData, (preNode || {}).id);
-		if (pre) {
-			Object.assign(pre, { isEdit: false, isAdd: false });
+		// 获取上一个节点
+		const previousNode = store.findNodeById(treeData, preNode && preNode.id);
+		if (previousNode) {
+			Object.assign(previousNode, { isEdit: false, isAdd: false });
 		}
 
-		const current = store.findNodeById(treeData, (currentNode || {}).id);
+		if (this.props.menuType === 'dialogMenu') {
+			this.onHideMenu();
+			this.setState({
+				showDialogMenu: true,
+				nodeData: isAdd ? { id: currentNode.id, level: currentNode.level } : currentNode,
+				parentNodeNames: this.getCurrentNodeOfParent(currentNode, isAdd),
+				isAddMenuOpen: isAdd
+			});
+			return;
+		}
+
+		const current = store.findNodeById(treeData, currentNode && currentNode.id);
 		if (current) {
 			Object.assign(current, { isEdit, isAdd });
 			if (isUnfold !== undefined) {
@@ -315,14 +373,14 @@ class Tree extends Component {
 	};
 
 	/**
-	 * 显示菜单
+	 * 显示右键菜单
 	 * @param node
 	 * @param menuStyle
 	 * @param options
 	 */
-	showMenu = (node, menuStyle, options) => {
+	onShowMenu = (node, menuStyle, options) => {
 		this.setState({
-			visibleMenu: true,
+			showRightMenu: true,
 			menuStyle,
 			nodeData: node,
 			menuOptions: options
@@ -330,15 +388,91 @@ class Tree extends Component {
 	};
 
 	/**
-	 * 隐藏菜单
+	 * 隐藏菜单弹出框
 	 */
-	hideMenu = () => {
-		if (!this.state.visibleMenu) {
+	onHideMenuDialog = () => {
+		if (!this.state.showDialogMenu) {
 			return;
 		}
 		this.setState({
-			visibleMenu: false
+			showDialogMenu: false
 		});
+	};
+
+	/**
+	 * 隐藏右键菜单
+	 */
+	onHideMenu = () => {
+		if (!this.state.showRightMenu) {
+			return;
+		}
+		this.setState({
+			showRightMenu: false
+		});
+	};
+
+	/**
+	 * 菜单名称输入
+	 * @param value
+	 */
+	onHandleInputNodeName = value => {
+		const tmp = this.state.nodeData;
+		this.setState({
+			nodeData: {
+				...tmp,
+				name: value
+			}
+		});
+	};
+
+	/**
+	 * 弹框菜单保存节点
+	 */
+	onSaveNode = () => {
+		const { id, name, level } = this.state.nodeData;
+		const isNameRepeat = this.onCheckRepeatNameAction(this.state.nodeData, name);
+		if (isNameRepeat) {
+			Message.error('该名称已存在');
+			return;
+		}
+		if (!name) {
+			Message.error('节点名称不能为空');
+			return;
+		}
+
+		if (this.state.isAddMenuOpen) {
+			// 新增
+			this.onAddAction(id, name, level);
+		} else {
+			// 重命名
+			this.onRenameAction(id, name);
+		}
+	};
+
+	/**
+	 * 查找到当前节点的所有父节点名称
+	 * @param currentNode
+	 * @param isAdd
+	 */
+	getCurrentNodeOfParent = (currentNode, isAdd) => {
+		const ancestryNames = [];
+		// 新建情况下需要添加当前节点名称
+		if (isAdd) {
+			ancestryNames.unshift(currentNode.name);
+		}
+		const getNames = pId => {
+			const pNode = store.findNodeById(this.state.treeData, pId);
+			if (!pNode) {
+				return;
+			}
+			ancestryNames.unshift(pNode.name);
+			if (pNode.pId || pNode.pId === 0) {
+				getNames(pNode.pId);
+			}
+		};
+		getNames(currentNode.pId);
+		const reg = new RegExp(',', 'g');
+		return ancestryNames.length > 0 && ancestryNames.join(',').replace(reg, '/');
 	};
 
 	render() {
@@ -355,16 +489,24 @@ class Tree extends Component {
 			nodeNameMaxLength,
 			supportCheckbox,
 			supportMenu,
+			supportDrag,
+			isShowNameTooltip,
+			menuType,
+			addMenuName,
 			isAddFront,
 			showIcon,
 			openIconType,
 			closeIconType,
 			iconColor,
-			selectedValue
+			selectedValue,
+			onDoubleClick,
+			onDragBefore,
+			onDragMoving,
+			onDragAfter
 		} = this.props;
 
-		const { onAddAction, onRenameAction, onRemoveAction, onSelectedAction, onFoldNodeAction, onCheckRepeatNameAction, showMenu, onReRenderNode } = this;
-		const { treeData, searchText, nodeData, menuStyle, menuOptions, visibleMenu } = this.state;
+		const { onAddAction, onRenameAction, onRemoveAction, onSelectedAction, onFoldNodeAction, onCheckRepeatNameAction, onShowMenu, onReRenderNode } = this;
+		const { treeData, searchText, nodeData, menuStyle, menuOptions, showRightMenu, showDialogMenu, parentNodeNames, isAddMenuOpen } = this.state;
 		const { id, name, disableAdd, disableRename, disableRemove } = nodeData;
 
 		return (
@@ -375,21 +517,29 @@ class Tree extends Component {
 					searchText,
 					supportCheckbox,
 					supportMenu,
+					supportDrag,
+					isShowNameTooltip,
 					isAddFront,
 					nodeNameMaxLength,
 					showIcon,
+					menuType,
+					addMenuName,
 					openIconType,
 					closeIconType,
 					iconColor,
 					selectedValue,
-					showMenu,
+					onDoubleClick,
+					onShowMenu,
 					onAddAction,
 					onRenameAction,
 					onRemoveAction,
 					onSelectedAction,
 					onFoldNodeAction,
 					onCheckRepeatNameAction,
-					onReRenderNode
+					onReRenderNode,
+					onDragBefore,
+					onDragMoving,
+					onDragAfter
 				}}>
 				<div className={`${selector} ${className}`} style={style}>
 					<Search
@@ -412,7 +562,7 @@ class Tree extends Component {
 						disableRemove={disableRemove}
 						options={menuOptions}
 						deleteNode={() => this.onRemoveAction(nodeData)}
-						visible={visibleMenu}
+						visible={showRightMenu}
 						onEditNodeBefore={onReRenderNode}
 					/>
 
@@ -423,6 +573,31 @@ class Tree extends Component {
 					)}
 
 					{(!treeData || !treeData.length) && <p>暂无结果</p>}
+
+					{showDialogMenu && (
+						<Modal
+							visible
+							title={isAddMenuOpen ? `新建${addMenuName}` : '重命名'}
+							modalStyle={menuModalStyle}
+							bodyStyle={menuModalBodyStyle}
+							onOk={this.onSaveNode}
+							onCancel={this.onHideMenuDialog}
+							onClose={this.onHideMenuDialog}>
+							<div style={{ color: '#666' }}>
+								<p style={{ marginBottom: 20 }}>{parentNodeNames}</p>
+								<span style={{ display: 'inline-block', lineHeight: '30px' }}>{addMenuName}名称：</span>
+								<Input
+									style={{ width: 300 }}
+									defaultValue={nodeData && nodeData.name}
+									onChange={e => this.onHandleInputNodeName(e.target.value)}
+									placeholder={`请输入${addMenuName}名称`}
+									hasClear
+									hasCounter
+									maxLength={nodeNameMaxLength}
+								/>
+							</div>
+						</Modal>
+					)}
 				</div>
 			</TreeContext.Provider>
 		);

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -1,17 +1,30 @@
 @import '../style/index';
 
 @selector: ~'@{prefix}-tree';
-
 @selector-search-icon: #dbdbdb;
 @selector-menu-border: 1px solid #e8e8e8;
-@selector-menu-hover: #e9e9e9;
+@selector-menu-hover: #f5f5f5;
 
 @selector-node-active-background: #eaf2fc;
 @display: inline-block;
+@overTowLine: {
+	white-space: normal;
+	word-break: break-all;
+	text-overflow: ellipsis;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	/*! autoprefixer: off */
+	-webkit-box-orient: vertical;
+	/* autoprefixer: on */
+	-moz-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+};
 
 .@{selector} {
 	position: relative;
 	user-select: none;
+
 	.@{prefix}-icon {
 		font-size: 14px;
 	}
@@ -22,7 +35,44 @@
 
 	li {
 		list-style: none;
-		cursor: pointer;
+		border-bottom: 2px solid transparent;
+		border-top: 2px solid transparent;
+	}
+
+	.move-bottom-style {
+		border-bottom: 2px solid #409eff;
+	}
+	.move-top-style {
+		border-top: 2px solid #409eff;
+	}
+	.insert-animation {
+		position: relative;
+		animation: insertAnimation 500ms linear; /*动画渐变变大，linear infinite让动画不断渐变不要停*/
+	}
+	@keyframes insertAnimation {
+		0% {
+			top: 0;
+			opacity: 0.1; /*渐变改变宽度和高度，并且设置opacity,使颜色越来越淡*/
+		}
+		25% {
+			top: -10px;
+			opacity: 0.3; /*渐变改变宽度和高度，并且设置opacity,使颜色越来越淡*/
+		}
+
+		50% {
+			top: 0;
+			opacity: 0.5;
+		}
+
+		75% {
+			top: 10px;
+			opacity: 0.75;
+		}
+
+		100% {
+			top: 0;
+			opacity: 1;
+		}
 	}
 
 	// 搜索组件
@@ -44,10 +94,12 @@
 	// 列表组件
 	&-list {
 		white-space: nowrap;
-		min-width: fit-content;
-		min-width: -moz-min-content;
-
+		width: 100%;
 		&-node-area {
+			//min-width: fit-content;
+			//min-width: -moz-min-content;
+			position: relative;
+			width: 100%;
 			.@{prefix}-icon {
 				display: @display;
 				height: 26px;
@@ -56,16 +108,68 @@
 				line-height: 26px;
 			}
 
+			.node-item-container {
+				padding-top: 2px;
+				padding-bottom: 2px;
+				position: relative;
+				&:hover {
+					.drag-icon {
+						display: inline-block;
+					}
+
+					.edit-icon {
+						display: block;
+						&:hover {
+							background: #ebebeb;
+						}
+					}
+				}
+				.toggle-icon {
+					cursor: pointer;
+					width: 26px;
+					border-radius: 2px;
+					text-align: center;
+					&:hover {
+						background: #ebebeb;
+					}
+				}
+				.drag-icon {
+					display: none;
+					width: 4px;
+					height: 10px;
+					position: absolute;
+					left: 6px;
+					cursor: move;
+					border-left: 2px dotted;
+					border-right: 2px dotted;
+					vertical-align: middle;
+					top: 10px;
+					color: #999;
+				}
+				.edit-icon {
+					display: none;
+					position: absolute;
+					right: 10px;
+					width: 26px;
+					height: 26px;
+					line-height: 22px;
+					color: #999;
+					cursor: pointer;
+					text-align: center;
+					font-weight: 700;
+				}
+			}
+
 			.node-item-container:not(.support-checkbox):hover {
-				background: @color-gray7;
+				background: @selector-menu-hover;
 			}
 
 			.node-item {
 				display: inline-flex;
-				height: 26px;
+				width: calc(100% - 50px);
 				border-radius: 2px;
 				line-height: 26px;
-				cursor: pointer;
+				//cursor: pointer;
 				padding: 0 4px;
 
 				.@{prefix}-checkbox {
@@ -93,8 +197,12 @@
 
 			.node-name {
 				display: @display;
+				width: 96%;
 				padding-left: 2px;
-				width: inherit;
+				@overTowLine();
+			}
+			.check-box-node-name {
+				@overTowLine();
 			}
 
 			.hot-text {
@@ -109,6 +217,7 @@
 				display: @display;
 				padding-left: 2px;
 			}
+
 			.save-icon {
 				color: #36cb37;
 			}
@@ -125,7 +234,7 @@
 		.child-style .node-item-container {
 			.node-item,
 			.is-rename {
-				margin-left: 14px;
+				margin-left: 20px;
 			}
 		}
 
@@ -146,14 +255,14 @@
 
 		> li {
 			line-height: 22px;
-
+			color: #3d3d3d;
 			&:hover {
 				background: @selector-menu-hover;
 			}
 
 			&.disabled {
 				cursor: not-allowed;
-				opacity: 0.6;
+				color: #999;
 			}
 		}
 	}

--- a/src/components/tree/index.md
+++ b/src/components/tree/index.md
@@ -22,6 +22,10 @@ subtitle: 树
 | maxLevel                 | 树结构最大支持层级，超过该层级则不可新增                             | Number   | -                 |
 | supportCheckbox          | 是否支持多选，false 为单选，true 为多选                              | Boolean  | false             |
 | supportMenu              | 是否支持右键菜单                                                     | Boolean  | true              |
+| isShowNameTooltip        | 是否显示节点名称tooltip                                                     | Boolean  | false              |
+| menuType                 | 菜单类型，支持弹框形式(dialogMenu)与右键菜单(rightMenu)形式，                    | String  | rightMenu              |
+| addMenuName              | 菜单类型为弹框类型时，弹框中显示的新增相关的名称                  | String  | 子目录              |
+| supportDrag              | 是否支持拖拽                                                     | Boolean  | false              |
 | isUnfold                 | 是否展开存在子节点的节点，默认不展开（根节点一直展开）               | Boolean  | false             |
 | showIcon                 | 是否显示节点前面的 icon                                              | Boolean  | false             |
 | openIconType             | 节点前面的展开 icon 类型，可在 icon 组件中查看相关类型               | String   | folder-solid-open |
@@ -30,12 +34,16 @@ subtitle: 树
 | supportImmediatelySearch | 是否支持实时搜索, supportSearch 必须为 true                          | Boolean  | false             |
 | supportSearch            | 是否支持搜索                                                         | Boolean  | false             |
 | isAddFront               | 新增节点时是否在当前节点的第一个子节点位置新增，false 则新增到最后面 | Boolean  | true              |
+| onDoubleClick            | 双击节点事件                                                       | Function | -                 |
 | onAddNode                | 新增节点事件，需要返回 Promise                                       | Function | -                 |
 | onRenameNode             | 重命名节点事件，需要返回 Promise                                     | Function | -                 |
 | onRemoveNode             | 删除节点事件，需要返回 Promise                                       | Function | -                 |
 | onSelectedNode           | 选中节点事件，返回选中的节点数据                                     | Function | -                 |
 | onSearchNode             | 节点搜索事件，返回搜索后的搜索值与搜索结果，搜索结果为搜索后的树结构 | Function | -                 |
-
+| onDragBefore             | 拖拽前调用      	    | Function	| -	|
+| onDragMoving             | 拖动过程中调用	    | Function	| -	|
+| onDragAfter              | 拖拽后调用	        | Function	| -	|
+ 
 ### 数据属性
 
 -   disableAdd: 布尔类型，设置为 true 则表示不可新增；

--- a/src/components/tree/list.js
+++ b/src/components/tree/list.js
@@ -1,22 +1,147 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Node from './node';
+import TreeContext from './context';
+import Store from './store';
+
+const store = new Store();
+
+let dropNode = null;
+let dragingNodePosition = null;
+let moveType = '';
+let dragingNode = null;
+let startData = null;
+let endData = null;
 
 class List extends Component {
+	static contextType = TreeContext;
+
+	/**
+	 * 开始拖动节点
+	 * @param e
+	 * @param data
+	 */
+	onDragNodeStart = (e, data) => {
+		e.stopPropagation();
+		// 确定开始节点
+		startData = data;
+		dragingNode = e.currentTarget;
+		dragingNodePosition = {
+			startY: e.clientY
+		};
+		this.context.onDragBefore(data);
+	};
+
+	/**
+	 * 移动节点中
+	 * @param e
+	 * @param data
+	 */
+	onDragNodeMoving = (e, data) => {
+		e.stopPropagation();
+		e.target.style.cursor = 'move';
+		this.context.onDragMoving(data, endData);
+	};
+
+	/**
+	 * 移动节点结束
+	 * @param e
+	 * @param data
+	 */
+	onDragNodeEnd = (e, data) => {
+		e.stopPropagation();
+		e.preventDefault();
+		const node = e.currentTarget;
+		const pNode = node.parentNode;
+		e.target.style.cursor = 'default';
+		Array.from(pNode.children).forEach(snode => {
+			// eslint-disable-next-line no-param-reassign
+			snode.className = '';
+		});
+
+		if (dropNode) {
+			node.className = 'insert-animation';
+			if (moveType === 'up') {
+				pNode.insertBefore(node, dropNode);
+			} else {
+				pNode.replaceChild(node, dropNode);
+				pNode.insertBefore(dropNode, node);
+			}
+		}
+
+		const pData = store.findNodeById(this.context.treeData, data.pId);
+		this.context.onDragAfter(data, endData, pData);
+	};
+
+	/**
+	 * 节点悬浮
+	 * @param e
+	 * @param data
+	 */
+	onDragNodeOver = (e, data) => {
+		e.stopPropagation();
+		e.preventDefault();
+		const node = e.currentTarget;
+		dropNode = node;
+		endData = data;
+		// 鼠标移动的距离
+		const moveRange = dragingNodePosition.startY - e.clientY;
+		// 相对与父级的位置
+		const relativeP = dragingNode.offsetTop - moveRange;
+		// 目标节点高度
+		const nodeHeight = node.offsetHeight;
+		const pNodeHeight = node.parentNode.offsetHeight;
+
+		if (data.pId === startData.pId) {
+			// 小于0则表示移出了，相对父级的位置如果大于节点的一半则在下，小于则在上
+			moveType = '';
+			node.className = 'move-bottom-style';
+			if (relativeP <= nodeHeight) {
+				node.className = 'move-top-style';
+				moveType = 'up';
+				return;
+			}
+			if (relativeP >= pNodeHeight - nodeHeight) {
+				moveType = 'down';
+			}
+		} else {
+			dropNode = null;
+			endData = null;
+		}
+	};
+
+	/**
+	 * 节点释放
+	 * @param e
+	 */
+	onDragNodeLeave = e => {
+		e.stopPropagation();
+		const node = e.currentTarget;
+		node.className = '';
+	};
+
 	render() {
 		const { data, prefixCls } = this.props;
 		return !data.length ? null : (
-			<div className={classNames(`${prefixCls}-list`)}>
+			<ul className={classNames(`${prefixCls}-list`)}>
 				{data.map(node => {
 					return (
-						<li key={node.id}>
+						<li
+							key={node.id}
+							id={node.id}
+							onDragStart={e => this.onDragNodeStart(e, node)}
+							onDrag={e => this.onDragNodeMoving(e, node)}
+							onDragEnd={e => this.onDragNodeEnd(e, node)}
+							onDragOver={e => this.onDragNodeOver(e, node)}
+							onDragLeave={this.onDragNodeLeave}
+							draggable={(node.pId || node.pId === 0) && this.context.supportDrag}>
 							<Node data={node} prefixCls={prefixCls}>
 								<List data={node.children} prefixCls={prefixCls} />
 							</Node>
 						</li>
 					);
 				})}
-			</div>
+			</ul>
 		);
 	}
 }

--- a/src/components/tree/menu.js
+++ b/src/components/tree/menu.js
@@ -23,8 +23,10 @@ class TreeMenu extends Component {
 	};
 
 	deleteNode = e => {
-		const { disableRemove } = this.props;
-		if (disableRemove) {
+		const { disableRemove, nodeData } = this.props;
+		const isDisabledDel = Array.isArray(nodeData.children) && nodeData.children.length;
+
+		if (disableRemove || isDisabledDel) {
 			e.preventDefault();
 			return;
 		}
@@ -55,18 +57,19 @@ class TreeMenu extends Component {
 
 	render() {
 		const { visible, nodeData, disableRemove, disableAdd, disableRename, menuStyle, prefixCls } = this.props;
+		const isDisabledDel = Array.isArray(nodeData.children) && nodeData.children.length;
 		return (
 			visible &&
 			this.context.supportMenu && (
 				<ul className={classNames(`${prefixCls}-menu`)} style={menuStyle}>
 					<li role="presentation" className={disableAdd ? 'disabled' : ''} onClick={e => this.addNode(e, nodeData)}>
-						新增
-					</li>
-					<li role="presentation" className={disableRemove ? 'disabled' : ''} onClick={this.deleteNode}>
-						删除
+						新增{this.context.addMenuName}
 					</li>
 					<li role="presentation" className={disableRename ? 'disabled' : ''} onClick={e => this.renameNode(e, nodeData)}>
 						重命名
+					</li>
+					<li role="presentation" className={disableRemove || isDisabledDel ? 'disabled' : ''} onClick={this.deleteNode}>
+						删除
 					</li>
 				</ul>
 			)


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [X] 新功能提交
-   [ ] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、解决某些场景中需要拖拽节点换位，增加supportDrag属性控制是否使用拖拽功能；增加onDragBefore、onDrag、onDragAfter用于拖拽前、拖拽中、拖拽后事件回调；
![image](https://user-images.githubusercontent.com/26587649/89623998-2ee46400-d8c8-11ea-8416-56a9ef5455e9.png)

2、增加双击节点事件；使用onDoubleClick触发双击节点事件；
3、增加弹框类型菜单；使用menuType进行菜单类型控制，可使用弹框形式与行内形式修改或 新建节点；
![image](https://user-images.githubusercontent.com/26587649/89624027-3b68bc80-d8c8-11ea-94e3-d9f2cfd4391b.png)

4、增加isShowNameTooltip用于控制是否显示节点 tooltip，因为要使用固定宽度的树且最多展示两行时，需要tootip；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [X] 文档已补充或无须补充
-   [X] 代码演示已提供或无须提供
