### PR TITLE
🐛 [TableLite]处理火狐浏览器下表头样式的兼容性问题

### DIFF
--- a/src/components/table-lite/index.js
+++ b/src/components/table-lite/index.js
@@ -176,9 +176,11 @@ export default class TableLite extends Component {
 						<thead>{theadContent}</thead>
 					</table>
 				</div>
+
 				<div className="cloud-table-lite-main">
-					<table style={{ height: dataSource.length ? 'auto' : '100%' }}>
-						<thead>{theadContent}</thead>
+					{!dataSource.length && <div style={{ height: 40 }}></div>}
+					<table style={{ height: dataSource.length ? 'auto' : 'calc(100% - 40px)' }}>
+						{dataSource.length > 0 && <thead>{theadContent}</thead>}
 						<tbody>{tbodyContent}</tbody>
 					</table>
 				</div>


### PR DESCRIPTION


### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [x] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

火狐浏览器中，TableLite组件在无数据的情况下，出现双表头，问题来自于火狐浏览器的兼容性问题。


### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
