### PR TITLE
[Tree]样式调整优化

### DIFF
--- a/src/components/tree/demos/defineStyle.markdown
+++ b/src/components/tree/demos/defineStyle.markdown
@@ -27,7 +27,7 @@ export default class TreeDemo extends React.Component {
 		const treeData = [
 			{
 				id: 1,
-				name: '所有',
+				name: '我是根节点',
 				pId: null,
 				children: [
 					{
@@ -46,41 +46,41 @@ export default class TreeDemo extends React.Component {
 					},
 					{
 						id: 12,
-						name: '禁止删除节点',
+						name: '别删除我，你删不掉的',
 						pId: 1,
 						disableRemove: true,
 						children: [
 							{
 								id: 121,
-								name: '禁止重命名节点',
+								name: '说了你还不信',
 								pId: 12,
 								disableRename: true,
 								children: [
 									{
 										id: 1211,
-										name: '2345',
+										name: '我爷爷说了，你试试！',
 										pId: 121
 									}
 								]
 							},
 							{
 								id: 122,
-								name: 'lerous',
+								name: '咳咳咳',
 								pId: 12
 							},
 							{
 								id: 123,
-								name: 'baukh321',
+								name: '哈哈哈',
 								pId: 12
 							},
 							{
 								id: 124,
-								name: 'bauh789',
+								name: '嘿嘿嘿',
 								pId: 12
 							},
 							{
 								id: 125,
-								name: 'baukh',
+								name: '吼吼吼',
 								pId: 12
 							}
 						]
@@ -94,17 +94,42 @@ export default class TreeDemo extends React.Component {
 			}
 		];
 		const style = {
-			color: '#333'
+			color: '#333',
+            width: '200px',
+            background: 'rgb(249,249,249)',
+            border: '1px solid #EEE'
 		};
 
-		return <Tree supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />;
+		return (
+            <>
+                <div className="tree-demo">
+                    <span>单选有弹框菜单</span>
+                    <Tree supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
+                </div>
+                <div className="tree-demo">
+                    <span>多选右键菜单</span>
+                    <Tree supportCheckbox supportMenu isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
+                </div>
+                <div className="tree-demo">
+                    <span>单选菜单</span>
+                    <Tree isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
+                </div>
+                <div className="tree-demo">
+                    <span>多选有弹框菜单</span>
+                    <Tree supportCheckbox supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
+                </div>
+            </>
+        );
 	}
 }
 ```
 
 ```less
+.tree-demo {
+  display: inline-block;
+  margin-right: 10px;
+}
 .bg {
-	width: 220px;
 	overflow: auto;
 	height: 300px;
 }

--- a/src/components/tree/demos/defineStyle.markdown
+++ b/src/components/tree/demos/defineStyle.markdown
@@ -46,13 +46,13 @@ export default class TreeDemo extends React.Component {
 					},
 					{
 						id: 12,
-						name: '别删除我，你删不掉的',
+						name: '别删除我，你删不掉11',
 						pId: 1,
 						disableRemove: true,
 						children: [
 							{
 								id: 121,
-								name: '说了你还不信',
+								name: '说了你还不信121',
 								pId: 12,
 								disableRename: true,
 								children: [
@@ -101,34 +101,19 @@ export default class TreeDemo extends React.Component {
 		};
 
 		return (
-            <>
-                <div className="tree-demo">
-                    <span>单选有弹框菜单</span>
-                    <Tree supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
-                </div>
-                <div className="tree-demo">
-                    <span>多选右键菜单</span>
-                    <Tree supportCheckbox supportMenu isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
-                </div>
-                <div className="tree-demo">
-                    <span>单选菜单</span>
-                    <Tree isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
-                </div>
-                <div className="tree-demo">
-                    <span>多选有弹框菜单</span>
-                    <Tree supportCheckbox supportMenu menuType="dialogMenu" isUnfold treeData={treeData} style={style} className="bg" showIcon={this.state.showIcon} onSelectedNode={this.selectedNode} />
-                </div>
-            </>
+             <Tree  supportMenu
+                    menuType="dialogMenu"
+                    isUnfold
+                    treeData={treeData}
+                    style={style} className="bg"
+                    showIcon={this.state.showIcon}
+                    onSelectedNode={this.selectedNode} />
         );
 	}
 }
 ```
 
 ```less
-.tree-demo {
-  display: inline-block;
-  margin-right: 10px;
-}
 .bg {
 	overflow: auto;
 	height: 300px;

--- a/src/components/tree/demos/menuDialog.markdown
+++ b/src/components/tree/demos/menuDialog.markdown
@@ -94,7 +94,7 @@ export default class TreeDemo extends React.Component {
 										children: [
 											{
 												id: 11321,
-												name: '禁止删除节点321',
+												name: '禁止删除节点321,测试一下宽度',
 												pId: 1132,
 												children: []
 											}
@@ -123,7 +123,7 @@ export default class TreeDemo extends React.Component {
 								children: [
 									{
 										id: 1211,
-										name: '禁止新增节点11',
+										name: '禁止新增节点11，测试一下宽',
 										pId: 121,
 										children: []
 									},
@@ -135,7 +135,7 @@ export default class TreeDemo extends React.Component {
 									},
 									{
 										id: 1213,
-										name: '禁止新增节点13',
+										name: '禁止新增节点13444444443',
 										pId: 121,
 										children: []
 									}
@@ -148,7 +148,7 @@ export default class TreeDemo extends React.Component {
 								children: [
 									{
 										id: 1221,
-										name: '禁止新增节点21',
+										name: '禁止新增节点214344566554443443',
 										pId: 122,
 										children: []
 									},
@@ -220,6 +220,12 @@ export default class TreeDemo extends React.Component {
 				]
 			}
 		];
+        const style = {
+			color: '#333',
+            width: '300px',
+            background: 'rgb(248 248 249)',
+            border: '1px solid #CCC'
+		};
 		return (
 			<Tree
 				treeData={treeData}
@@ -229,6 +235,8 @@ export default class TreeDemo extends React.Component {
 				maxLevel={this.state.maxLevel}
 				supportMenu
                 isUnfold
+                supportCheckbox
+                style={style}
                 menuType="dialogMenu"
                 addMenuName="分类"
 				onAddNode={this.addNode}

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -44,7 +44,6 @@ class Tree extends Component {
 		iconColor: '#999',
 		supportCheckbox: false,
 		supportMenu: false,
-		isShowNameTooltip: false,
 		menuType: MENU_TYPE,
 		addMenuName: '子目录',
 		supportSearch: false,
@@ -78,7 +77,6 @@ class Tree extends Component {
 		iconColor: PropTypes.string,
 		supportCheckbox: PropTypes.bool,
 		supportMenu: PropTypes.bool,
-		isShowNameTooltip: PropTypes.bool,
 		menuType: PropTypes.string,
 		addMenuName: PropTypes.string,
 		supportSearch: PropTypes.bool,
@@ -112,11 +110,14 @@ class Tree extends Component {
 			menuStyle: null,
 			menuOptions: null,
 			searchText: '',
+			treeWidth: 0,
 			treeData: ShuyunUtils.clone(treeData),
 			allTreeData: ShuyunUtils.clone(treeData),
 			prevProps: props,
 			preSelectedNode: props.selectedValue && props.selectedValue[0]
 		};
+
+		this.treeAreaRef = React.createRef();
 	}
 
 	// 监听外部回显数据变化
@@ -138,6 +139,9 @@ class Tree extends Component {
 	componentDidMount() {
 		document.addEventListener('scroll', this.onHideMenu, true);
 		document.addEventListener('click', this.onHideMenu);
+		this.setState({
+			treeWidth: this.treeAreaRef.current.clientWidth
+		});
 	}
 
 	componentWillUnmount() {
@@ -490,7 +494,6 @@ class Tree extends Component {
 			supportCheckbox,
 			supportMenu,
 			supportDrag,
-			isShowNameTooltip,
 			menuType,
 			addMenuName,
 			isAddFront,
@@ -506,7 +509,7 @@ class Tree extends Component {
 		} = this.props;
 
 		const { onAddAction, onRenameAction, onRemoveAction, onSelectedAction, onFoldNodeAction, onCheckRepeatNameAction, onShowMenu, onReRenderNode } = this;
-		const { treeData, searchText, nodeData, menuStyle, menuOptions, showRightMenu, showDialogMenu, parentNodeNames, isAddMenuOpen } = this.state;
+		const { treeData, searchText, treeWidth, nodeData, menuStyle, menuOptions, showRightMenu, showDialogMenu, parentNodeNames, isAddMenuOpen } = this.state;
 		const { id, name, disableAdd, disableRename, disableRemove } = nodeData;
 
 		return (
@@ -518,10 +521,10 @@ class Tree extends Component {
 					supportCheckbox,
 					supportMenu,
 					supportDrag,
-					isShowNameTooltip,
 					isAddFront,
 					nodeNameMaxLength,
 					showIcon,
+					treeWidth,
 					menuType,
 					addMenuName,
 					openIconType,
@@ -567,7 +570,7 @@ class Tree extends Component {
 					/>
 
 					{treeData && treeData.length > 0 && (
-						<div className={classNames(`${selector}-list-container`)}>
+						<div className={classNames(`${selector}-list-container`)} ref={this.treeAreaRef}>
 							<TreeList prefixCls={selector} nodeNameMaxLength={nodeNameMaxLength} data={treeData} />
 						</div>
 					)}
@@ -584,7 +587,7 @@ class Tree extends Component {
 							onCancel={this.onHideMenuDialog}
 							onClose={this.onHideMenuDialog}>
 							<div style={{ color: '#666' }}>
-								<p style={{ marginBottom: 20 }}>{parentNodeNames}</p>
+								<p style={{ marginBottom: 20, lineHeight: '26px', wordBreak: 'break-all' }}>{parentNodeNames}</p>
 								<span style={{ display: 'inline-block', lineHeight: '30px' }}>{addMenuName}名称：</span>
 								<Input
 									style={{ width: 300 }}

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -593,6 +593,7 @@ class Tree extends Component {
 									style={{ width: 300 }}
 									defaultValue={nodeData && nodeData.name}
 									onChange={e => this.onHandleInputNodeName(e.target.value)}
+									onEnter={this.onSaveNode}
 									placeholder={`请输入${addMenuName}名称`}
 									hasClear
 									hasCounter

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -8,17 +8,13 @@
 @selector-node-active-background: #eaf2fc;
 @display: inline-block;
 @overTowLine: {
-	white-space: normal;
-	word-break: break-all;
+	display: @display;
+	word-break: normal;
 	text-overflow: ellipsis;
-	display: -webkit-box;
-	-webkit-box-orient: vertical;
-	/*! autoprefixer: off */
-	-webkit-box-orient: vertical;
-	/* autoprefixer: on */
-	-moz-box-orient: vertical;
-	-webkit-line-clamp: 2;
 	overflow: hidden;
+};
+@dialog-menu-node-name: {
+	@overTowLine();
 };
 
 .@{selector} {
@@ -95,9 +91,11 @@
 	&-list {
 		white-space: nowrap;
 		width: 100%;
+		color: @color-gray2;
+		&-container {
+			padding: 0 10px;
+		}
 		&-node-area {
-			//min-width: fit-content;
-			//min-width: -moz-min-content;
 			position: relative;
 			width: 100%;
 			.@{prefix}-icon {
@@ -109,8 +107,6 @@
 			}
 
 			.node-item-container {
-				padding-top: 2px;
-				padding-bottom: 2px;
 				position: relative;
 				&:hover {
 					.drag-icon {
@@ -149,7 +145,7 @@
 				.edit-icon {
 					display: none;
 					position: absolute;
-					right: 10px;
+					right: 0;
 					width: 26px;
 					height: 26px;
 					line-height: 22px;
@@ -166,17 +162,22 @@
 
 			.node-item {
 				display: inline-flex;
-				width: calc(100% - 50px);
+				width: calc(100% - 26px);
 				border-radius: 2px;
 				line-height: 26px;
-				//cursor: pointer;
-				padding: 0 4px;
 
 				.@{prefix}-checkbox {
 					display: inline-flex;
-					width: 94%;
+					width: 100%;
 					z-index: 10;
-
+					&-text {
+						height: 26px;
+						width: calc(100% - 22px);
+						.dialog-menu-check-node-name {
+							@overTowLine();
+							width: 100%;
+						}
+					}
 					.@{prefix}-icon-check-circle-solid {
 						padding-right: 4px;
 					}
@@ -197,12 +198,13 @@
 
 			.node-name {
 				display: @display;
-				width: 96%;
+				width: 100%;
 				padding-left: 2px;
 				@overTowLine();
 			}
-			.check-box-node-name {
+			.dialog-menu-node-name {
 				@overTowLine();
+				width: calc(100% - 25px);
 			}
 
 			.hot-text {
@@ -210,7 +212,7 @@
 			}
 
 			.is-add {
-				padding-left: 34px;
+				padding-left: 47px;
 			}
 
 			.is-rename {
@@ -234,7 +236,7 @@
 		.child-style .node-item-container {
 			.node-item,
 			.is-rename {
-				margin-left: 20px;
+				margin-left: 27px;
 			}
 		}
 
@@ -245,17 +247,19 @@
 
 	// 菜单组件
 	&-menu {
-		width: 86px;
+		width: fit-content;
 		position: fixed;
-		text-align: center;
+		text-align: left;
 		z-index: 100;
 		padding: 3px 0 !important;
 		border: @selector-menu-border;
 		background-color: @color-white;
 
 		> li {
+			cursor: pointer;
 			line-height: 22px;
-			color: #3d3d3d;
+			color: @color-gray2;
+			padding: 0 10px;
 			&:hover {
 				background: @selector-menu-hover;
 			}

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -31,15 +31,15 @@
 
 	li {
 		list-style: none;
-		border-bottom: 2px solid transparent;
-		border-top: 2px solid transparent;
+		border-bottom: 1px solid transparent;
+		border-top: 1px solid transparent;
 	}
 
 	.move-bottom-style {
-		border-bottom: 2px solid #409eff;
+		border-bottom: 1px solid #409eff;
 	}
 	.move-top-style {
-		border-top: 2px solid #409eff;
+		border-top: 1px solid #409eff;
 	}
 	.insert-animation {
 		position: relative;
@@ -139,7 +139,7 @@
 					border-left: 2px dotted;
 					border-right: 2px dotted;
 					vertical-align: middle;
-					top: 10px;
+					top: 8px;
 					color: #999;
 				}
 				.edit-icon {
@@ -229,7 +229,7 @@
 			}
 
 			.is-active:not(.support-checkbox) {
-				background: @selector-node-active-background;
+				background: @selector-node-active-background !important;
 			}
 		}
 

--- a/src/components/tree/index.md
+++ b/src/components/tree/index.md
@@ -22,7 +22,6 @@ subtitle: 树
 | maxLevel                 | 树结构最大支持层级，超过该层级则不可新增                             | Number   | -                 |
 | supportCheckbox          | 是否支持多选，false 为单选，true 为多选                              | Boolean  | false             |
 | supportMenu              | 是否支持右键菜单                                                     | Boolean  | true              |
-| isShowNameTooltip        | 是否显示节点名称tooltip                                                     | Boolean  | false              |
 | menuType                 | 菜单类型，支持弹框形式(dialogMenu)与右键菜单(rightMenu)形式，                    | String  | rightMenu              |
 | addMenuName              | 菜单类型为弹框类型时，弹框中显示的新增相关的名称                  | String  | 子目录              |
 | supportDrag              | 是否支持拖拽                                                     | Boolean  | false              |

--- a/src/components/tree/node.js
+++ b/src/components/tree/node.js
@@ -264,6 +264,7 @@ function ShowInput({ isEdit, isAdd, maxLength, inputValue, handleInputChange, sa
  * @param searchText
  * @param menuType
  * @param supportMenu
+ * @param treeWidth
  * @param indentValue
  * @param indeterminate
  * @param checked
@@ -302,20 +303,20 @@ function ShowSelection({
 	let nodeWidth = 0;
 	if (treeWidth > 0) {
 		let correctWidth = 0;
-		if (!supportCheckbox && !supportMenu) {
-			// 单选无菜单
+		if (!supportCheckbox && (!supportMenu || (supportMenu && menuType === RIGHT_MENU))) {
+			// 单选无菜单或有右键菜单
 			correctWidth = 46;
 		}
 		if (!supportCheckbox && supportMenu && menuType === DIALOG_MENU) {
-			// 单选有菜单
+			// 单选有菜单且为弹框菜单
 			correctWidth = 71;
 		}
-		if (supportCheckbox && !supportMenu) {
-			// 多选无菜单
-			correctWidth = 72;
+		if (supportCheckbox && (!supportMenu || (supportMenu && menuType === RIGHT_MENU))) {
+			// 多选无菜单或有右键菜单
+			correctWidth = 66;
 		}
-		if (supportCheckbox && supportMenu) {
-			// 多选有菜单
+		if (supportCheckbox && supportMenu && menuType === DIALOG_MENU) {
+			// 多选有菜单且为弹框菜单
 			correctWidth = 102;
 		}
 		nodeWidth = treeWidth - indentValue - correctWidth;


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [ ] 日常 bug 修复
-   [ ] 站点、文档改进
-   [X] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案
1、由上个版本中单个节点最多显示两行跳整为显示一行；
2、设置固定宽度后，如果节点长度超过计算的宽度则显示tooltip；
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、节点调整为单行显示，超过指定宽度显示...，鼠标悬浮显示完整节点名称；
2、节点被选中后，鼠标悬浮则背景色显示选中的背景色；

### ☑️ 请求合并前的自查清单

-   [X] 文档已补充或无须补充
-   [X] 代码演示已提供或无须提供
