### PR TITLE
:bug: [tree][tree-select] 修复tree组件中数据为空时ref报错问题

### DIFF
--- a/src/components/tree-select/tree.js
+++ b/src/components/tree-select/tree.js
@@ -9,6 +9,14 @@ import { selector, MULTIPLE } from './const';
 
 import './index.less';
 
+const OptionsEmpty = ({ emptyRender, ...props }) => {
+	return (
+		<div className={`${selector}-empty-options`} {...props}>
+			{' '}
+			{emptyRender}{' '}
+		</div>
+	);
+};
 class TreeContainer extends React.Component {
 	get buttons() {
 		const { okBtnText, cancelBtnText, resetBtnText, onOk, onCancel, onReset } = this.props;
@@ -36,21 +44,36 @@ class TreeContainer extends React.Component {
 	};
 
 	render() {
-		const { dataSource, type, searchable, value, hasConfirmButton, footerTypes, dropdownClassName, dropdownStyle, style, ...otherProps } = this.props;
+		const {
+			dataSource,
+			type,
+			searchable,
+			value,
+			hasConfirmButton,
+			footerTypes,
+			dropdownClassName,
+			dropdownStyle,
+			style,
+			emptyRender,
+			...otherProps
+		} = this.props;
 		const classNames = cls(`${selector}-options`, dropdownClassName, {
 			[`${selector}-options-confirm`]: hasConfirmButton
 		});
 		return (
 			<div className={classNames} style={dropdownStyle}>
-				<Tree
-					{...otherProps}
-					supportSearch={searchable}
-					selectedValue={value}
-					onSelectedNode={this.selectNode}
-					treeData={dataSource}
-					supportCheckbox={type === MULTIPLE}
-				/>
+				{dataSource.length > 0 && (
+					<Tree
+						{...otherProps}
+						supportSearch={searchable}
+						selectedValue={value}
+						onSelectedNode={this.selectNode}
+						treeData={dataSource}
+						supportCheckbox={type === MULTIPLE}
+					/>
+				)}
 				{hasConfirmButton && <div className={`${selector}-operate-btn`}>{footerTypes.map(v => this.buttons[v])}</div>}
+				{!dataSource.length && <OptionsEmpty emptyRender={emptyRender} />}
 			</div>
 		);
 	}

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -140,7 +140,7 @@ class Tree extends Component {
 		document.addEventListener('scroll', this.onHideMenu, true);
 		document.addEventListener('click', this.onHideMenu);
 		this.setState({
-			treeWidth: this.treeAreaRef.current.clientWidth
+			treeWidth: this.treeAreaRef?.current?.clientWidth
 		});
 	}
 


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [X] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
tree组件中当数据源为空时dom节点不渲染导致使用ref报错；

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->
1、修复tree组件中数据为空时获取ref报错问题；
2、优化tree-select组件中数据为空的显示方式；

### ☑️ 请求合并前的自查清单

-   [X] 文档已补充或无须补充
-   [X] 代码演示已提供或无须提供
