### PR TITLE
[tree]增加多选可筛选功能

### DIFF
--- a/src/components/tree-select/demos/multiple.markdown
+++ b/src/components/tree-select/demos/multiple.markdown
@@ -81,18 +81,39 @@ export default class TreeSelectDemo extends React.Component {
 				}
 			]
 		};
+        setTimeout(() => {
+           this.setState({
+              confirmNodes: [
+                 {
+                 					id: 113,
+                 					name: '删除三个',
+                 					pId: 11,
+                 					children: [
+                 						{
+                 							id: 1131,
+                 							name: '禁止删除节点31',
+                 							pId: 113,
+                 							children: []
+                 						},
+                 						{
+                 							id: 1132,
+                 							name: '禁止删除节点32',
+                 							pId: 113,
+                 							children: [
+                 								{
+                 									id: 11321,
+                 									name: '禁止删除节点321',
+                 									pId: 1132,
+                 									children: []
+                 								}
+                 							]
+                 						}
+                 					]
+                 				}
+              ]
+           });
+        }, 1000);
 
-		setTimeout(() => {
-			this.setState({
-				confirmNodes: [
-					{
-						id: 112,
-						name: '删除两个',
-						pId: 11
-					}
-				]
-			});
-		}, 1000);
 	}
 
 	handleChange = (node, selectedNodes) => {
@@ -137,6 +158,7 @@ export default class TreeSelectDemo extends React.Component {
 				/>
 				<TreeSelect
 					type="multiple"
+                    searchable
 					hasConfirmButton
 					isUnfold
 					allowClear

--- a/src/components/tree/demos/basicSelector.markdown
+++ b/src/components/tree/demos/basicSelector.markdown
@@ -19,7 +19,8 @@ export default class TreeDemo extends React.Component {
 			maxLevel: 4,
 			supportMenu: true,
 			supportSearch: true,
-			isAddFront: false
+			isAddFront: false,
+            selectedValue: null
 		};
 	}
 
@@ -234,6 +235,7 @@ export default class TreeDemo extends React.Component {
 		];
 		return (
 			<Tree
+                selectedValue = {this.state.selectedValue}
 				treeData={treeData}
 				searchPlaceholder={this.state.searchPlaceholder}
 				searchMaxLength={this.state.searchMaxLength}
@@ -243,6 +245,7 @@ export default class TreeDemo extends React.Component {
 				supportMenu={this.state.supportMenu}
 				supportSearch={this.state.supportSearch}
 				isAddFront={this.state.isAddFront}
+                supportCheckbox={true}
 				onAddNode={this.addNode}
 				onDoubleClick={this.onDoubleClick}
 				onRenameNode={this.renameNode}

--- a/src/components/tree/demos/multipleSelect.markdown
+++ b/src/components/tree/demos/multipleSelect.markdown
@@ -14,7 +14,7 @@ export default class TreeDemo extends React.Component {
 
 		this.state = {
 			supportMenu: false,
-			supportSearch: false,
+			supportSearch: true,
 			supportCheckbox: true
 		};
 	}
@@ -197,7 +197,7 @@ export default class TreeDemo extends React.Component {
 				]
 			}
 		];
-		return <Tree treeData={treeData} supportCheckbox={this.state.supportCheckbox} onSelectedNode={this.selectedNode}></Tree>;
+		return <Tree treeData={treeData} supportSearch={this.state.supportSearch} supportCheckbox={this.state.supportCheckbox} onSelectedNode={this.selectedNode}></Tree>;
 	}
 }
 ```

--- a/src/components/tree/index.js
+++ b/src/components/tree/index.js
@@ -33,7 +33,7 @@ class Tree extends Component {
 	static defaultProps = {
 		style: {},
 		className: '',
-		searchPlaceholder: '',
+		searchPlaceholder: '搜索一个选项',
 		searchMaxLength: '',
 		nodeNameMaxLength: '',
 		maxLevel: 0,
@@ -114,7 +114,8 @@ class Tree extends Component {
 			treeData: ShuyunUtils.clone(treeData),
 			allTreeData: ShuyunUtils.clone(treeData),
 			prevProps: props,
-			preSelectedNode: props.selectedValue && props.selectedValue[0]
+			preSelectedNode: props.selectedValue && props.selectedValue[0],
+			preSelectedList: store.getSelectedLowestNodeList(props.selectedValue)
 		};
 
 		this.treeAreaRef = React.createRef();
@@ -129,7 +130,8 @@ class Tree extends Component {
 				selectedValue: nextProps.selectedValue,
 				preSelectedNode: nextProps.selectedValue && nextProps.selectedValue[0],
 				prevProps: nextProps,
-				treeData: store.initData(prevState.treeData, prevProps.maxLevel, nextProps.selectedValue)
+				treeData: store.initData(prevState.treeData, prevProps.maxLevel, nextProps.selectedValue),
+				preSelectedList: store.getSelectedLowestNodeList(nextProps.selectedValue)
 			};
 		}
 
@@ -171,17 +173,27 @@ class Tree extends Component {
 		this.setState({
 			searchText
 		});
-		const { supportSearch, onSearchNode } = this.props;
+		const { supportSearch, supportCheckbox, onSearchNode } = this.props;
 
 		const tmp = ShuyunUtils.clone(this.state.allTreeData);
 
 		// 搜索结果数据
 		const backTree = store.searchNode(tmp, searchText);
 
-		// 是多选并且存在已多选的节点列表才进行合并数据
-		this.setState({
-			treeData: [...backTree]
-		});
+		if (supportSearch && supportCheckbox) {
+			const currentSelectedTemp = this.getSelectedMoreList(this.state.treeData);
+			// eslint-disable-next-line react/no-access-state-in-setstate
+			const allSelectedLowest = store.getSelectedLowestNodeList(this.state.preSelectedList, currentSelectedTemp);
+
+			this.setState({
+				treeData: store.initData([...backTree], null, [...allSelectedLowest], this.props.isUnfold),
+				preSelectedList: allSelectedLowest
+			});
+		} else {
+			this.setState({
+				treeData: [...backTree]
+			});
+		}
 
 		// 支持搜索则返回搜素结果
 		if (supportSearch && onSearchNode) {
@@ -196,14 +208,23 @@ class Tree extends Component {
 	onSelectedAction = node => {
 		this.onHideMenu();
 		const data = this.state.treeData;
-		const { supportCheckbox, onSelectedNode } = this.props;
+		const { supportSearch, supportCheckbox, onSelectedNode } = this.props;
 
 		// 更新节点选中状态
 		this.updateActiveNode(data, node);
 		// 单选节点列表
 		const radioSelectedList = store.selectedForRadio(data, node);
 		// 多选节点列表
-		const checkboxSelectedList = this.getSelectedMoreList(data, node);
+		let checkboxSelectedList = this.getSelectedMoreList(data, node);
+
+		if (supportCheckbox) {
+			checkboxSelectedList = store.getSelectedLowestNodeList(this.state.preSelectedList, checkboxSelectedList, node);
+			if (supportSearch) {
+				this.setState({
+					preSelectedList: checkboxSelectedList
+				});
+			}
+		}
 
 		// 选中结果
 		const selectedResult = supportCheckbox ? checkboxSelectedList : radioSelectedList;
@@ -226,9 +247,12 @@ class Tree extends Component {
 	 */
 	getSelectedMoreList = (data, node) => {
 		const selectedList = [];
-		this.updateActiveNode(data, node);
-		// 更新checked状态
-		const tmp = store.selectedForCheckbox(data, node);
+		let tmp = data;
+		if (node) {
+			this.updateActiveNode(data, node);
+			// 更新checked状态
+			tmp = store.selectedForCheckbox(data, node);
+		}
 		const filterSelected = selectedData => {
 			selectedData.forEach(item => {
 				if (item.checked) {
@@ -549,7 +573,7 @@ class Tree extends Component {
 						prefixCls={selector}
 						onSearchAction={this.onSearchAction}
 						supportImmediatelySearch={supportImmediatelySearch}
-						supportSearch={supportSearch && !supportCheckbox}
+						supportSearch={supportSearch}
 						searchPlaceholder={searchPlaceholder}
 						searchMaxLength={searchMaxLength}
 					/>

--- a/src/components/tree/index.less
+++ b/src/components/tree/index.less
@@ -76,8 +76,9 @@
 		padding-bottom: 10px;
 
 		.@{prefix}-input-group {
-			width: 100%;
-			line-height: 30px;
+			width: calc(100% - 10px);
+			margin-left: 5px;
+			line-height: 25px;
 		}
 
 		.icon-search {

--- a/src/components/tree/search.js
+++ b/src/components/tree/search.js
@@ -33,6 +33,7 @@ class Search extends Component {
 			supportSearch && (
 				<div className={classNames(`${prefixCls}-search`)}>
 					<Input
+						size="small"
 						suffix={<Icon type="search" onClick={this.handleSearch} style={{ cursor: 'pointer' }} />}
 						className={classNames(`${prefixCls}-search-input`)}
 						onEnter={this.handleSearch}

--- a/src/components/tree/store.js
+++ b/src/components/tree/store.js
@@ -93,16 +93,18 @@ class Store {
 			}
 
 			// 找到treeData中对应的值进行选中
-			const activeNodeIndex = selectedValue && selectedValue.findIndex(x => x.id === tmp.id);
-			if (activeNodeIndex !== -1) {
-				// 当前节点选中
-				tmp.checked = true;
-				// 被选中的元素有子节点，则子节点全部选中
-				if (tmp.children.length) {
-					downFind(tmp);
+			if (selectedValue) {
+				const activeNodeIndex = selectedValue.findIndex(x => x.id === tmp.id);
+				if (activeNodeIndex !== -1) {
+					// 当前节点选中
+					tmp.checked = true;
+					// 被选中的元素有子节点，则子节点全部选中
+					if (tmp.children.length) {
+						downFind(tmp);
+					}
+					// 寻找父节点
+					upFind(tmp);
 				}
-				// 寻找父节点
-				upFind(tmp);
 			}
 
 			if (!children || !children.length) {
@@ -250,6 +252,44 @@ class Store {
 		changeParent(pId);
 		return data;
 	}
+
+	/**
+	 * 获取所有选中数据的最底层节点
+	 * @param preAry 上一次树选中的节点
+	 * @param curAry 当前树选中的节点
+	 * @param node 当前操作的节点
+	 * @returns {*|*[]}
+	 */
+	getSelectedLowestNodeList = (preAry, curAry, node = null) => {
+		let preAryTemp = preAry || [];
+		const curAryTemp = curAry || [];
+		// 首先，判断是选中还是不选中， 选中--则不处理，不选中--移除
+		if (preAryTemp.length && node && !node.checked) {
+			const removeTemp = [];
+			const getRemoveTemp = n => {
+				const { children } = n;
+				if (children && children.length) {
+					children.forEach(c => {
+						getRemoveTemp(c);
+					});
+				} else {
+					removeTemp.push(n);
+				}
+			};
+			getRemoveTemp(node);
+			preAryTemp = preAryTemp.filter(pre => !removeTemp.find(y => y.id === pre.id));
+		}
+		let temp = [...preAryTemp, ...curAryTemp];
+		// 两个数组取并集，且移除掉有children属性的节点
+		temp = temp.reduce((returnData, item) => {
+			const obj = returnData.find(i => i.id === item.id);
+			if (!obj && (!item.children || !item.children.length)) {
+				returnData.push(item);
+			}
+			return returnData;
+		}, []);
+		return temp;
+	};
 
 	/**
 	 * 根据参数获取节点


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [x] 新功能提交
-   [ ] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案
背景：商品选择器中的自定义类目和标准类目下拉树多选框增加模糊搜索功能
解决方案：树组件在多选的情况下增加模糊搜索功能

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充或无须补充
-   [ ] 代码演示已提供或无须提供
