### PR TITLE
[datepicker]支持手动输入时间

### DIFF
--- a/src/components/datepicker/common/picker.js
+++ b/src/components/datepicker/common/picker.js
@@ -10,8 +10,8 @@ import YearMonth from '../year-month/main';
 import MonthDay from '../month-day/main';
 import DatePicker from '../date-picker/main';
 import { renderDOM, createWrapper, destroyDOM } from './utils';
-import { enumObj, containerClass, selectorClass, wrapperClass, FORMAT } from '../constant';
-import { transformObj, displayNow } from '../utils';
+import { enumObj, enumCheck, containerClass, selectorClass, wrapperClass, FORMAT } from '../constant';
+import { transformObj, displayNow, checkFormat } from '../utils';
 
 class Picker extends Component {
 	static contextType = ContextProvider;
@@ -29,13 +29,27 @@ class Picker extends Component {
 				.replace('.', ''),
 			visible: open,
 			style: {},
-			prevProps: props
+			prevProps: props,
+			checkFlag: true // 校验输入的日期格式是否正确
 		};
 
 		this.inpRef = createRef();
 		this.popupRef = createRef();
 
 		this.containerRef = createRef();
+
+		this.setYearChild = ref => {
+			this.yearChild = ref;
+		};
+		this.setYearMonthChild = ref => {
+			this.yearMonthChild = ref;
+		};
+		this.setMonthDayChild = ref => {
+			this.monthDayChild = ref;
+		};
+		this.setDateChild = ref => {
+			this.dateChild = ref;
+		};
 	}
 
 	static getDerivedStateFromProps(props, prevState) {
@@ -62,14 +76,10 @@ class Picker extends Component {
 	componentDidUpdate(prevProps) {
 		const { value: prevValue, open: prevOpen } = prevProps;
 		const { value, open } = this.props;
-
+		const { checkFlag } = this.state;
 		if (prevValue !== value) {
-			if (value) {
-				const date = displayNow(new Date(value));
-				this.handleValueChange(date);
-			} else {
-				this.handleChange();
-			}
+			const date = checkFlag && value ? displayNow(new Date(value)) : value;
+			this.handleValueChange(date, false);
 		}
 		if (prevOpen !== open) {
 			this.changeVisible(open);
@@ -94,39 +104,54 @@ class Picker extends Component {
 		return getContext() || this.document.body;
 	}
 
-	handleValueChange = (output = '', isPop = false) => {
-		const value = this.props.formatValue(output);
+	/**
+	 *
+	 * @param output
+	 * @param isPop
+	 * @param isClickBtn 是否是点击确定
+	 */
+	handleValueChange = (output = '', isPop = false, isClickBtn = false) => {
+		const { checkFlag } = this.state;
+		const value = (output && checkFlag) || isClickBtn ? this.props.formatValue(output) : output || '';
 		this.setState({
-			currentValue: value
+			currentValue: value ? value.toString().replace(/-/g, '/') : ''
 		});
 		if (isPop) {
 			this.props.onChange(value);
 		}
 	};
 
-	onPopChange = output => {
-		this.handleValueChange(output, true);
-		this.changeVisible(false);
+	/**
+	 * 值跑出去
+	 * @param output 抛出去的值
+	 * @param isClickBtn 是否是点击确定按钮 -- 确定：true   回车/失去焦点：false
+	 */
+	onPopChange = (output, isClickBtn = true) => {
+		this.handleValueChange(output, true, isClickBtn);
+		this.changeVisible(false); // 关闭日历选择
 	};
 
 	renderMainPop = () => {
-		const { tempMode, formatValue } = this.props;
+		const { tempMode, formatValue, showTimePicker } = this.props;
 		const { currentValue } = this.state;
-		const checkValue = currentValue ? formatValue(displayNow(new Date(currentValue)), this.format) : '';
+
+		const checkFlag = checkFormat(currentValue, tempMode, showTimePicker);
+
+		const checkValue = checkFlag && currentValue ? formatValue(displayNow(new Date(currentValue)), this.format) : '';
 
 		if (tempMode === enumObj.YEAR_MODEL) {
-			return <Year {...this.props} checkValue={currentValue} onChange={this.onPopChange} />;
+			return <Year ref={this.setYearChild} {...this.props} checkValue={currentValue} onChange={this.onPopChange} />;
 		}
 
 		if (tempMode === enumObj.YEAR_MONTH_MODEL) {
-			return <YearMonth {...this.props} checkValue={checkValue} onChange={this.onPopChange} />;
+			return <YearMonth ref={this.setYearMonthChild} {...this.props} checkValue={checkValue} onChange={this.onPopChange} />;
 		}
 
 		if (tempMode === enumObj.MONTH_DAY_MODEL) {
-			return <MonthDay {...this.props} checkValue={checkValue} onChange={this.onPopChange} />;
+			return <MonthDay ref={this.setMonthDayChild} {...this.props} checkValue={checkValue} onChange={this.onPopChange} />;
 		}
 
-		return <DatePicker {...this.props} checkValue={transformObj(checkValue)} onChange={this.onPopChange} />;
+		return <DatePicker ref={this.setDateChild} {...this.props} checkValue={transformObj(checkValue)} onChange={this.onPopChange} />;
 	};
 
 	popClick = evt => {
@@ -136,11 +161,30 @@ class Picker extends Component {
 		}
 	};
 
+	// 关闭时 校验输入的是否正确
 	handleClick = e => {
 		const isClickPicker = this.containerRef.current.contains(e.target) || (this.popupRef.current && this.popupRef.current.contains(e.target));
+		const { checkFlag, visible, currentValue } = this.state;
+		const { tempMode, formatValue } = this.props;
 
-		if (!isClickPicker && this.state.visible) {
+		// 校验不通过，且有值，直接抛出去，日历选择器关闭
+		if (!isClickPicker && !checkFlag && visible) {
+			this.props.onChange(currentValue);
 			this.changeVisible(false);
+			return;
+		}
+
+		// 校验通过，值为空
+		if (!isClickPicker && visible && !currentValue) {
+			this.onPopChange('', false);
+			return;
+		}
+
+		// 校验通过，正常值
+		if (!isClickPicker && currentValue && visible) {
+			const currentValueTemp =
+				tempMode === enumObj.YEAR_MODEL ? { year: currentValue } : transformObj(formatValue(displayNow(new Date(this.checkTimePicker())), this.format));
+			this.onPopChange(currentValueTemp, false);
 		}
 	};
 
@@ -160,7 +204,6 @@ class Picker extends Component {
 				this.setState({ style });
 			} else {
 				createWrapper(id, height, style);
-
 				renderDOM(
 					id,
 					containerRef.current,
@@ -226,18 +269,98 @@ class Picker extends Component {
 	};
 
 	handleChange = (evt = '') => {
-		if (!evt || !evt.target.value.trim().length) {
-			this.props.onChange('');
+		const { tempMode, showTimePicker } = this.props;
+		if (evt.target) {
+			// 点击了清空操作，空值抛出去
+			if (!evt.target.value && evt.type === 'click') {
+				this.onPopChange('', false);
+				return;
+			}
+
+			const { currentValue } = this.state;
+
+			// 可输入长度 可输入斜杠数
+			const { replaceRule, lenRule, backslashRule } = enumCheck[showTimePicker ? 'DATE_TIME_MODEL' : tempMode];
+
+			const currentValueTemp = evt.target.value?.replace(replaceRule, ''); // 根据正则过滤掉符合的输入内容
+			const currentValueFinal =
+				currentValueTemp.length > lenRule || currentValueTemp.split('/').length > backslashRule + 1 ? currentValue.toString() : currentValueTemp;
+
 			this.setState({
-				currentValue: ''
+				currentValue: currentValueFinal
 			});
+
+			// 值改变的时候，日历要显示出来
+			if (!this.state.visible && currentValueFinal) {
+				this.changeVisible(true);
+			}
+
+			// 校验输入的值是否正确
+			const checkFlag = currentValueFinal ? checkFormat(currentValueFinal.trim(), tempMode, showTimePicker) : true;
+
+			this.setState({
+				checkFlag
+			});
+
+			// 校验通过 并且有值 日历选择联动
+			if (checkFlag && currentValueFinal) {
+				if (tempMode === enumObj.YEAR_MODEL) {
+					this.yearChild.changeCheckValue(currentValueFinal);
+				} else if (tempMode === enumObj.YEAR_MONTH_MODEL) {
+					this.yearMonthChild.changeCheckValue(currentValueFinal);
+				} else if (tempMode === enumObj.MONTH_DAY_MODEL) {
+					this.monthDayChild.changeCheckValue(currentValueFinal);
+				} else if (this.dateChild) {
+					const afterV = currentValueFinal.trim().split(' ')[1]; // 拿到年月日时分秒的数值
+					const dealData = transformObj(currentValueFinal);
+					// hour: 'other', minute: 'other', second: 'other'  方式時分秒重置，具體看date-picker/grid.js配合使用
+					this.dateChild.changeCheckValue(afterV ? dealData : { ...dealData, hour: 'other', minute: 'other', second: 'other' });
+					// this.dateChild.changeCheckValue( afterV ? dealData : { ...dealData, hour: null, minute: null, second: null } );
+				}
+			}
 		}
 	};
 
+	handleEnterDown = () => {
+		const { formatValue, tempMode } = this.props;
+		const { checkFlag, currentValue } = this.state;
+
+		// 校验不通过或者为空，直接抛出去
+		if (!checkFlag || !currentValue) {
+			this.props.onChange(currentValue);
+			this.changeVisible(false);
+			return;
+		}
+
+		// 校验通过 数值抛出去
+		const currentValueTemp =
+			tempMode === enumObj.YEAR_MODEL ? { year: currentValue } : transformObj(formatValue(displayNow(new Date(this.checkTimePicker())), this.format));
+		this.onPopChange(currentValueTemp, false);
+	};
+
+	/**
+	 * 显示时分秒的时候，增加自动补全功能
+	 */
+	checkTimePicker = () => {
+		const { currentValue } = this.state;
+		const { defaultTime, showTimePicker, formatValue } = this.props;
+		let returnValue = currentValue.trim();
+		const afterV = returnValue.split(' ')[1];
+		if (showTimePicker && returnValue && !afterV) {
+			// 校验年月日格式是否正确，正确 补全 校验设置为true；不正确 不补全
+			returnValue = this.props.formatValue(transformObj(formatValue(displayNow(new Date(`${currentValue.trim()} ${defaultTime}`)), this.format)));
+			this.setState({
+				currentValue: returnValue
+			});
+		}
+
+		return returnValue;
+	};
+
 	render() {
-		const { inpRef, containerRef, onClickInput, handleChange } = this;
+		const { inpRef, containerRef, onClickInput, handleChange, handleEnterDown } = this;
 		const { currentValue, visible, style } = this.state;
-		const { placeholder, disabled, isAppendToBody, width, className, ...others } = this.props;
+		const { canEdit, placeholder, disabled, isAppendToBody, width, className, ...others } = this.props;
 		const otherProps = omit(others, [
 			'value',
 			'containerEleClass',
@@ -263,7 +386,7 @@ class Picker extends Component {
 					<Input
 						{...otherProps}
 						style={{ width: `${parseFloat(width)}px` }}
-						readOnly
+						readOnly={!canEdit}
 						hasClear
 						ref={inpRef}
 						value={currentValue}
@@ -271,6 +394,7 @@ class Picker extends Component {
 						onChange={handleChange}
 						disabled={disabled}
 						className={`${selectorClass}-inp`}
+						onEnter={handleEnterDown}
 						suffix={<Icon type="calendar" className={`${selectorClass}-inp-icon`} onClick={onClickInput} />}
 					/>
 				</div>
@@ -298,7 +422,8 @@ Picker.propTypes = {
 	value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]),
 	formatValue: PropTypes.func,
 	onChange: PropTypes.func,
-	onClose: PropTypes.func
+	onClose: PropTypes.func,
+	canEdit: PropTypes.bool
 };
 
 Picker.defaultProps = {
@@ -311,7 +436,8 @@ Picker.defaultProps = {
 	value: undefined,
 	formatValue: noop,
 	onChange: noop,
-	onClose: noop
+	onClose: noop,
+	canEdit: false
 };
 
 export default Picker;

--- a/src/components/datepicker/common/time.js
+++ b/src/components/datepicker/common/time.js
@@ -31,9 +31,9 @@ class Time extends Component {
 
 	componentDidUpdate(prevProps) {
 		const { value: prevValue } = prevProps;
-		const { value, type } = this.props;
+		const { value } = this.props;
 
-		if (prevValue !== value && type === 'alone') {
+		if (prevValue !== value) {
 			this.updateState();
 		}
 	}

--- a/src/components/datepicker/constant.js
+++ b/src/components/datepicker/constant.js
@@ -22,7 +22,36 @@ export const enumObj = {
 	DATE_TIME_MODEL: 'DATE_TIME_MODEL'
 };
 
+export const enumCheck = {
+	YEAR_MODEL: {
+		replaceRule: /[^\d]/g,
+		lenRule: 4,
+		backslashRule: 0
+	},
+	YEAR_MONTH_MODEL: {
+		replaceRule: /[^\d/]/g,
+		lenRule: 7,
+		backslashRule: 1
+	},
+	MONTH_DAY_MODEL: {
+		replaceRule: /[^\d/]/g,
+		lenRule: 5,
+		backslashRule: 1
+	},
+	DATE_MODEL: {
+		replaceRule: /[^\d/]/g,
+		lenRule: 10,
+		backslashRule: 2
+	},
+	DATE_TIME_MODEL: {
+		replaceRule: /[^' '\d:/]/g,
+		lenRule: 19,
+		backslashRule: 2
+	}
+};
+
 export const FORMAT = {
+	[enumObj.YEAR_MODEL]: 'YYYY',
 	[enumObj.YEAR_MONTH_MODEL]: 'YYYY/MM',
 	[enumObj.MONTH_DAY_MODEL]: 'MM/DD',
 	[enumObj.DATE_MODEL]: 'yyyy/MM/dd'

--- a/src/components/datepicker/date-picker/grid.js
+++ b/src/components/datepicker/date-picker/grid.js
@@ -34,11 +34,13 @@ class Grid extends Component {
 	updateState() {
 		const { hour, minute, second } = this.props.checkValue || {};
 		const _defaultTimes = this.props.defaultTime.split(':');
-		this.setState({
-			tempHour: hour || _defaultTimes[0],
-			tempMinute: minute || _defaultTimes[1],
-			tempSecond: second || _defaultTimes[2]
-		});
+		if (hour !== 'other') {
+			this.setState({
+				tempHour: hour || _defaultTimes[0],
+				tempMinute: minute || _defaultTimes[1],
+				tempSecond: second || _defaultTimes[2]
+			});
+		}
 	}
 
 	static getDerivedStateFromProps(props, state) {

--- a/src/components/datepicker/date-picker/index.js
+++ b/src/components/datepicker/date-picker/index.js
@@ -8,9 +8,11 @@ import { PROPTYPES, DEFAULT_PROPS } from '../proptypes';
 class DatePicker extends Component {
 	constructor(props) {
 		super(props);
-
-		this.height = props.showTimePicker ? 339 : 289;
-		this.tempMode = props.showTimePicker ? enumObj.DATE_TIME_MODEL : enumObj.DATE_MODE;
+		const { showTimePicker, placeholder } = props;
+		const tempPlaceholder = showTimePicker ? 'yyyy/mm/dd hh:mm:ss' : 'yyyy/mm/dd';
+		this.height = showTimePicker ? 339 : 289;
+		this.tempMode = showTimePicker ? enumObj.DATE_TIME_MODEL : enumObj.DATE_MODEL;
+		this.placeholder = placeholder || tempPlaceholder;
 	}
 
 	formatValue = ({ year, month, day, hour, minute, second }, formatRule) => {
@@ -24,7 +26,8 @@ class DatePicker extends Component {
 	};
 
 	render() {
-		return <Picker {...this.props} tempMode={enumObj.DATE_MODEL} height={this.height} formatValue={this.formatValue} />;
+		const tempProps = { ...this.props, placeholder: this.placeholder };
+		return <Picker {...tempProps} tempMode={enumObj.DATE_MODEL} height={this.height} formatValue={this.formatValue} />;
 	}
 }
 
@@ -41,7 +44,7 @@ DatePicker.propTypes = {
 DatePicker.defaultProps = {
 	...DEFAULT_PROPS,
 	format: 'yyyy/MM/dd',
-	placeholder: '请选择日期',
+	placeholder: '',
 	minYear: 1980,
 	maxYear: 2030,
 	showTimePicker: false,

--- a/src/components/datepicker/date-picker/main.js
+++ b/src/components/datepicker/date-picker/main.js
@@ -5,7 +5,7 @@ import Header from '../common/header';
 import Grid from './grid';
 import { displayNow, transformObj } from '../utils';
 
-class Popup extends Component {
+class DatePicker extends Component {
 	constructor(props) {
 		super(props);
 
@@ -14,11 +14,22 @@ class Popup extends Component {
 		const now = displayNow();
 
 		this.state = {
+			checkValue,
 			tempYear: checkValue ? checkValue.year : now.year,
 			tempMonth: checkValue ? checkValue.month : now.month,
 			tempDay: checkValue ? checkValue.day : null
 		};
 	}
+
+	changeCheckValue = checkValue => {
+		const now = displayNow();
+		this.setState({
+			checkValue,
+			tempYear: checkValue ? checkValue.year : now.year,
+			tempMonth: checkValue ? checkValue.month : now.month,
+			tempDay: checkValue ? checkValue.day : null
+		});
+	};
 
 	onHeaderChange = (year, month) => {
 		this.setState({
@@ -36,9 +47,8 @@ class Popup extends Component {
 	};
 
 	render() {
-		const { minDate, maxDate, showTimePicker, maxYear, minYear, onChange, checkValue, defaultTime } = this.props;
-		const { tempYear, tempMonth, tempDay } = this.state;
-
+		const { minDate, maxDate, showTimePicker, maxYear, minYear, onChange, defaultTime } = this.props;
+		const { checkValue, tempYear, tempMonth, tempDay } = this.state;
 		return (
 			<>
 				<Header
@@ -67,7 +77,7 @@ class Popup extends Component {
 	}
 }
 
-Popup.propTypes = {
+DatePicker.propTypes = {
 	minDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
 	maxDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
 	checkValue: PropTypes.object,
@@ -75,7 +85,7 @@ Popup.propTypes = {
 	onChange: PropTypes.func
 };
 
-Popup.defaultProps = {
+DatePicker.defaultProps = {
 	showTimePicker: false,
 	checkValue: undefined,
 	minDate: undefined,
@@ -83,4 +93,4 @@ Popup.defaultProps = {
 	onChange: noop
 };
 
-export default Popup;
+export default DatePicker;

--- a/src/components/datepicker/date-range/index.js
+++ b/src/components/datepicker/date-range/index.js
@@ -25,15 +25,19 @@ class DateRange extends Component {
 			const { start, end } = value;
 			return { start, end };
 		}
+		if (value === undefined) {
+			return { start: '', end: '' };
+		}
 		return null;
 	}
 
 	onChangeStartTime = start => {
-		this.setState({ endOpen: true });
+		this.setState({ start, endOpen: true });
 		this.props.onChange({ start, end: this.state.end });
 	};
 
 	onChangeEndTime = end => {
+		this.setState({ end });
 		this.props.onChange({ start: this.state.start, end });
 	};
 
@@ -43,13 +47,14 @@ class DateRange extends Component {
 
 	render() {
 		const { onChangeStartTime, onChangeEndTime, onEndClose } = this;
-		const { minDate, maxDate, width = 480, className, ...others } = this.props;
+		const { minDate, maxDate, width = 480, className, onChange, ...others } = this.props;
+
 		const { start, end, endOpen } = this.state;
 
 		const startValue = start ? new Date(start) : '';
 		const endValue = end ? new Date(end) : '';
 		const props = omit(others, ['value', 'defaultValue', 'data-field']);
-		const wraperProps = omit(props, ['showTimePicker', 'isAppendToBody']);
+		const wraperProps = omit(props, ['showTimePicker', 'isAppendToBody', 'canEdit']);
 		const pickerWidth = (parseFloat(width) - 20) / 2;
 
 		return (
@@ -57,7 +62,7 @@ class DateRange extends Component {
 				<DatePicker
 					{...props}
 					width={`${pickerWidth}px`}
-					value={startValue}
+					value={start}
 					minDate={minDate}
 					maxDate={endValue || maxDate}
 					onChange={onChangeStartTime}
@@ -67,7 +72,7 @@ class DateRange extends Component {
 				<DatePicker
 					{...props}
 					width={`${pickerWidth}px`}
-					value={endValue}
+					value={end}
 					minDate={startValue || minDate}
 					maxDate={maxDate}
 					open={endOpen}

--- a/src/components/datepicker/demos/date-picker.markdown
+++ b/src/components/datepicker/demos/date-picker.markdown
@@ -6,7 +6,7 @@ desc: 基本用法，日期选择器。
 
 ```javascript
 import React from 'react';
-import { Datepicker } from 'cloud-react';
+import { Datepicker, Button } from 'cloud-react';
 
 export default class DatePickerDemo extends React.Component {
 	constructor(props) {
@@ -14,50 +14,61 @@ export default class DatePickerDemo extends React.Component {
 
 		this.state = {
 			visible: false,
-			range: { start: '2020-04-23 00:00:00', end: '2020-06-07 23:59:59' },
-			value: '2020/07/10'
+			value1: '',
+            value: '1990/07/10',
+            tValue1: '',
+            tValue2: ''
 		};
 	}
 
-	onInpChange = range => {
-		this.setState({ range });
-	};
-
-	onChangeDate = date => {
-		console.log(date);
+	onChangeDate1 = date => {
+        this.setState({value1: date});
+		console.log('最终数值-------------', date);
 	}
+    onChangeDateT = data => {
+		this.setState({tValue2: data});
+		console.log('最终数值-------------', data);
+	}
+
+    reset = () => {
+       this.setState({value1: '2020/07/10'})
+	   console.log('重置');
+    }
 
 	render() {
 		return (
 			<div>
-				<Datepicker
-					isAppendToBody
-					value={this.state.value}
-					position="auto"
-					onChange={this.onChangeDate}
-					width="200px"
-					placeholder="年月日"
-				/>
+                <div>
+                    不可编辑：<Datepicker isAppendToBody
+                         				 value={this.state.value}
+                         				 position="auto"/>
+                    <span style={{paddingLeft: 20}}>可编辑</span>：
+                            <Datepicker isAppendToBody
+                                        canEdit={true}
+                                        minDate={'1990/3/1'}
+                                        maxDate={new Date('2024/5/1')}
+                         				value={this.state.value1}
+                         				position="auto"
+                         				onChange={this.onChangeDate1}/>
+                <Button style={{marginLeft: 20}} onClick={this.reset}> 重置 </Button>
+                </div>
 				<br />
 				<br />
-				<Datepicker
-					position="auto"
-					value="2021/01/07"
-					showTimePicker={true}
-					placeholder="年月日 时分秒"
-				/>
-				<br />
-				<br />
-				<Datepicker.RangePicker
-					width={420}
-					position="auto"
-					value={this.state.range}
-					minDate={new Date('2020/3/1')}
-					maxDate={new Date('2024/5/1')}
-					onChange={this.onInpChange}
-					showTimePicker
-					isAppendToBody
-				/>
+                <div>
+                    不可编辑：<Datepicker isAppendToBody
+                         				 value={this.state.tValue1}
+                                         showTimePicker
+                         				 position="auto"/>
+                    <span style={{paddingLeft: 20}}>可编辑</span>：
+                            <Datepicker isAppendToBody
+                                        canEdit={true}
+                         				value={this.state.tValue2}
+                         				position="auto"
+                                        showTimePicker
+                                        defaultTime="23:59:59"
+                         				onChange={this.onChangeDateT}/>
+                </div>
+
 			</div>
 		);
 	}

--- a/src/components/datepicker/demos/disabled.markdown
+++ b/src/components/datepicker/demos/disabled.markdown
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 6
 title: 禁用
 desc: 选择框的不可用状态。
 ---
@@ -12,22 +12,22 @@ export default class DatePickerDemo extends React.Component {
 	render() {
 		return (
 			<div>
-				<Datepicker.YearPicker disabled value="" placeholder="年" />
+				<Datepicker.YearPicker disabled value=""  />
 				<br />
 				<br />
-				<Datepicker.YearMonthPicker disabled value="" placeholder="年月" />
+				<Datepicker.YearMonthPicker disabled value=""  />
 				<br />
 				<br />
-				<Datepicker.MonthDayPicker disabled value="" placeholder="月日" />
+				<Datepicker.MonthDayPicker disabled value="" />
 				<br />
 				<br />
 				<Datepicker.TimePicker disabled value="" />
 				<br />
 				<br />
-				<Datepicker disabled placeholder="年月日" />
+				<Datepicker disabled  />
 				<br />
 				<br />
-				<Datepicker disabled showTimePicker={true} placeholder="年月日 时分秒" />
+				<Datepicker disabled showTimePicker={true}  />
 				<br />
 				<br />
 			</div>

--- a/src/components/datepicker/demos/modal.markdown
+++ b/src/components/datepicker/demos/modal.markdown
@@ -1,5 +1,5 @@
 ---
-order: 7
+order: 8
 title: 嵌套使用
 desc: modal弹框里面使用datepicker自适应位置
 ---

--- a/src/components/datepicker/demos/month-day-picker.markdown
+++ b/src/components/datepicker/demos/month-day-picker.markdown
@@ -11,11 +11,12 @@ import { Datepicker } from 'cloud-react';
 export default class DatePickerDemo extends React.Component {
 	onChange = value => console.log(value);
 	render() {
-		return (
-			<div>
-				<Datepicker.MonthDayPicker min="06/10" position="auto" onChange={this.onChange} />
-			</div>
-		);
+        return (
+                <div>
+                    不可编辑：<Datepicker.MonthDayPicker min="01/10" position="auto" onChange={this.onChange} />
+                    <span style={{paddingLeft: 20}}>可编辑</span>：<Datepicker.MonthDayPicker canEdit={true} min="01/10" position="auto" onChange={this.onChange} />
+                </div>
+                )
 	}
 }
 ```

--- a/src/components/datepicker/demos/range-date-picker.markdown
+++ b/src/components/datepicker/demos/range-date-picker.markdown
@@ -1,0 +1,67 @@
+---
+order: 5
+title: 区间选择器
+desc: 基本用法。
+---
+
+```javascript
+import React from 'react';
+import { Datepicker, Button } from 'cloud-react';
+
+export default class DatePickerDemo extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			visible: false,
+			range1: { start: '2020/04/23', end: '2020/06/07' },
+            range2:  { start: '2020/04/20 00:00:00', end: '2020/06/20 23:59:59' }
+		};
+	}
+
+	onInpChange1 = range1 => {
+		this.setState({ range1 });
+        console.log(range1, '不可编辑区间');
+	};
+
+	onInpChange2 = range2 => {
+        this.setState({ range2 });
+        console.log(range2, '可编辑区间');
+	}
+
+    reset = () => {
+        this.setState({
+            range2: { start: '2020/04/20 00:00:00', end: '2020/06/20 23:59:59' }
+        })
+    }
+
+
+	render() {
+		return (
+            <>
+		    <div>
+               <p style={{marginBottom: 10, marginTop: 20}}>不可编辑：</p>
+                <Datepicker.RangePicker
+               					position="auto"
+               					value={this.state.range1}
+               					onChange={this.onInpChange1}
+               					isAppendToBody
+               				/>
+			</div>
+			<div>
+               <p style={{marginBottom: 10, marginTop: 20}}>可编辑：</p>
+                <Datepicker.RangePicker
+               					position="auto"
+               					value={this.state.range2}
+               					onChange={this.onInpChange2}
+               					isAppendToBody
+                                showTimePicker
+                                canEdit
+               				/>
+            <Button style={{marginTop: 20}} onClick={this.reset}> 重置 </Button>
+			</div>
+            </>
+		);
+	}
+}
+```

--- a/src/components/datepicker/demos/time-picker.markdown
+++ b/src/components/datepicker/demos/time-picker.markdown
@@ -1,5 +1,5 @@
 ---
-order: 5
+order: 7
 title: 时间选择器
 desc: 基本用法，时间选择器。
 ---

--- a/src/components/datepicker/demos/year-month-picker.markdown
+++ b/src/components/datepicker/demos/year-month-picker.markdown
@@ -9,10 +9,26 @@ import React from 'react';
 import { Datepicker } from 'cloud-react';
 
 export default class DatePickerDemo extends React.Component {
-	onChange = value => console.log(value);
+
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			value: '2021/01',
+		};
+	}
+    onChange = value => console.log('年月--', value);
+
+
 
 	render() {
-		return <Datepicker.YearMonthPicker position="auto" onChange={this.onChange} min="2018/04" />;
+	return (
+                <div>
+                    不可编辑：<Datepicker.YearMonthPicker position="auto" onChange={this.onChange} min="2018/04" max="2022/04"/>
+                    <span style={{paddingLeft: 20}}>可编辑</span>：
+                    <Datepicker.YearMonthPicker value={this.state.value} canEdit={true} position="auto"  max="2022/04" onChange={this.onChange} format={'yyyy-mm'}/>
+                </div>
+                )
 	}
 }
 ```

--- a/src/components/datepicker/demos/year-picker.markdown
+++ b/src/components/datepicker/demos/year-picker.markdown
@@ -12,7 +12,12 @@ export default class DatePickerDemo extends React.Component {
 	onInpChange = value => console.log(value);
 
 	render() {
-		return <Datepicker.YearPicker min={2014} position="auto" max={2034} defaultValue={2020} onChange={this.onInpChange} />;
+		return (
+                <div>
+                    不可编辑：<Datepicker.YearPicker min={2014} position="auto" max={2034} defaultValue={2020} onChange={this.onInpChange} />
+                    <span style={{paddingLeft: 20}}>可编辑</span>：<Datepicker.YearPicker canEdit min={2014} position="auto" max={2034} defaultValue={2020} onChange={this.onInpChange} />
+                </div>
+                )
 	}
 }
 ```

--- a/src/components/datepicker/index.md
+++ b/src/components/datepicker/index.md
@@ -40,6 +40,7 @@ subtitle: 日期选择框
 | containerEleClass | 需要滚动的元素 class 名称                          | string                  | -                 |
 | isAppendToBody    | 日历选择弹框是否渲染在 body 上                     | boolean                 | `false`           |
 | position          | 日历选择框是否启用自动定位，如需使用可设置为`auto` | string                  | -                 |
+| canEdit           | 是否可编辑                                     | boolean                 | `false`           |
 
 ### TimePicker
 
@@ -51,6 +52,7 @@ subtitle: 日期选择框
 | value        | 当前值(手动清空可绑定 state) | string                  | -       |
 | onChange     | 选择日期改变                 | Function(value: object) | -       |
 | onBlur       | 失去焦点时触发               | Function(evt)           | -       |
+| canEdit      | 是否可编辑                   | boolean                 | `false`           |
 
 ### YearPicker
 
@@ -65,6 +67,7 @@ subtitle: 日期选择框
 | min          | 最小值                            | number/string           | -            |
 | max          | 最大值                            | number/string           | -            |
 | onChange     | 选择年份改变                      | Function(value: string) | -            |
+| canEdit      | 是否可编辑                   | boolean                 | `false`           |
 
 ### YearMonthPicker
 
@@ -80,6 +83,7 @@ subtitle: 日期选择框
 | max          | 最大值                            | string           | -              |
 | format       | 格式化输出格式                    | string                  | `默认 YYYY/MM` |
 | onChange     | 选择年月改变                      | Function(value: string) | -              |
+| canEdit      | 是否可编辑                   | boolean                 | `false`           |
 
 ### MonthDayPicker
 
@@ -95,3 +99,4 @@ subtitle: 日期选择框
 | max          | 最大值                            | string           | -            |
 | format       | 格式化输出格式                    | string                  | `默认 MM/DD` |
 | onChange     | 选择月日改变                      | Function(value: string) | -            |
+| canEdit      | 是否可编辑                   | boolean                 | `false`           |

--- a/src/components/datepicker/month-day/index.js
+++ b/src/components/datepicker/month-day/index.js
@@ -25,7 +25,7 @@ MonthDayPicker.propTypes = {
 MonthDayPicker.defaultProps = {
 	...DEFAULT_PROPS,
 	format: 'MM/DD',
-	placeholder: '请选择月日'
+	placeholder: 'mm/dd'
 };
 
 export default MonthDayPicker;

--- a/src/components/datepicker/month-day/main.js
+++ b/src/components/datepicker/month-day/main.js
@@ -7,7 +7,7 @@ import { monthArr } from '../constant';
 import { formatZero, displayNow } from '../utils';
 import Grid from './grid';
 
-class Popup extends Component {
+class MonthDay extends Component {
 	constructor(props) {
 		super(props);
 
@@ -18,6 +18,13 @@ class Popup extends Component {
 			tempDay: checkValue ? parseInt(checkValue.split('/')[1], 10) : ''
 		};
 	}
+
+	changeCheckValue = checkValue => {
+		this.setState({
+			tempMonth: checkValue ? parseInt(checkValue.split('/')[0], 10) : displayNow().month,
+			tempDay: checkValue ? parseInt(checkValue.split('/')[1], 10) : ''
+		});
+	};
 
 	handleLeftClick = () => {
 		const { tempMonth } = this.state;
@@ -97,14 +104,14 @@ class Popup extends Component {
 	}
 }
 
-Popup.propTypes = {
+MonthDay.propTypes = {
 	checkValue: PropTypes.string,
 	onChange: PropTypes.func
 };
 
-Popup.defaultProps = {
+MonthDay.defaultProps = {
 	checkValue: '',
 	onChange: noop
 };
 
-export default Popup;
+export default MonthDay;

--- a/src/components/datepicker/proptypes.js
+++ b/src/components/datepicker/proptypes.js
@@ -4,6 +4,7 @@ import { noop } from '@utils';
 export const PROPTYPES = {
 	className: PropTypes.string,
 	disabled: PropTypes.bool,
+	canEdit: PropTypes.bool,
 	defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]),
 	value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object, PropTypes.instanceOf(Date)]),
 	open: PropTypes.bool,
@@ -17,6 +18,7 @@ export const PROPTYPES = {
 export const DEFAULT_PROPS = {
 	className: '',
 	disabled: false,
+	canEdit: false,
 	defaultValue: undefined,
 	value: undefined,
 	open: false,

--- a/src/components/datepicker/year-month/grid.js
+++ b/src/components/datepicker/year-month/grid.js
@@ -16,9 +16,7 @@ function formatData(value) {
 class MonthGrid extends Component {
 	constructor(props) {
 		super(props);
-
 		const { checkValue } = props;
-
 		this.state = {
 			tempMonth: checkValue ? formatData(checkValue) : null
 		};
@@ -26,7 +24,6 @@ class MonthGrid extends Component {
 
 	componentDidUpdate(prevProps) {
 		const { checkValue } = this.props;
-
 		if (prevProps.checkValue !== checkValue) {
 			this.updateTempMonth(formatData(checkValue));
 		}
@@ -64,15 +61,16 @@ class MonthGrid extends Component {
 
 	getClassName = (_tempMonth, current, _month) => {
 		const { selectedYear, min, max } = this.props;
+		const { splitStr } = this.state;
 
 		if (_tempMonth && parseInt(_tempMonth, 10) === current) {
 			return 'grid-check';
 		}
 
-		const maxYear = parseInt(max.split('/')[0], 10);
-		const minYear = parseInt(min.split('/')[0], 10);
-		const maxYearMonth = parseInt(max.split('/')[1], 10);
-		const minYearMonth = parseInt(min.split('/')[1], 10);
+		const maxYear = parseInt(max.split(splitStr)[0], 10);
+		const minYear = parseInt(min.split(splitStr)[0], 10);
+		const maxYearMonth = parseInt(max.split(splitStr)[1], 10);
+		const minYearMonth = parseInt(min.split(splitStr)[1], 10);
 		if (currentYear > maxYear || currentYear < minYear) {
 			return ` ${disClass} `;
 		}

--- a/src/components/datepicker/year-month/index.js
+++ b/src/components/datepicker/year-month/index.js
@@ -29,5 +29,5 @@ YearMonthPicker.defaultProps = {
 	min: '1900/01',
 	max: '2100/12',
 	format: 'YYYY/MM',
-	placeholder: '请选择年月'
+	placeholder: 'yyyy/mm'
 };

--- a/src/components/datepicker/year-month/main.js
+++ b/src/components/datepicker/year-month/main.js
@@ -3,7 +3,7 @@ import { displayNow } from '../utils';
 import Select from '../../select';
 import MonthGrid from './grid';
 
-export default class Popup extends Component {
+export default class YearMonth extends Component {
 	constructor(props) {
 		super(props);
 
@@ -12,14 +12,24 @@ export default class Popup extends Component {
 		this.minYear = parseInt(min.split('/')[0], 10);
 		this.maxYear = parseInt(max.split('/')[0], 10);
 
+		const { checkValue } = props;
+
 		this.state = {
-			tempYear: this.getInitTempYear()
+			checkValue,
+			tempYear: this.getInitTempYear(checkValue)
 		};
 	}
 
-	getInitTempYear() {
+	changeCheckValue = checkValue => {
+		this.setState({
+			checkValue,
+			tempYear: this.getInitTempYear(checkValue)
+		});
+	};
+
+	getInitTempYear(checkValue) {
 		const currentYear = displayNow().year;
-		const { checkValue } = this.props;
+
 		const { minYear, maxYear } = this;
 
 		if (checkValue) {
@@ -51,8 +61,8 @@ export default class Popup extends Component {
 	};
 
 	render() {
-		const { tempYear } = this.state;
-		const { checkValue, min, max } = this.props;
+		const { checkValue, tempYear } = this.state;
+		const { min, max, format } = this.props;
 
 		const years = [];
 
@@ -71,7 +81,7 @@ export default class Popup extends Component {
 						{years}
 					</Select>
 				</div>
-				<MonthGrid checkValue={checkValue} max={max} min={min} selectedYear={tempYear} onChange={this.handleMonthGridChange} />
+				<MonthGrid checkValue={checkValue} max={max} min={min} selectedYear={tempYear} format={format} onChange={this.handleMonthGridChange} />
 			</>
 		);
 	}

--- a/src/components/datepicker/year/grid.js
+++ b/src/components/datepicker/year/grid.js
@@ -33,6 +33,19 @@ class YearGrid extends Component {
 		};
 	}
 
+	componentDidUpdate(prevProps) {
+		const { checkValue } = this.props;
+		if (prevProps.checkValue !== checkValue) {
+			this.updateTempYear(checkValue);
+		}
+	}
+
+	updateTempYear(value) {
+		this.setState({
+			tempYear: value
+		});
+	}
+
 	getDisabledNow = () => {
 		const { min, max } = this.props;
 		const { year } = displayNow();

--- a/src/components/datepicker/year/index.js
+++ b/src/components/datepicker/year/index.js
@@ -30,5 +30,5 @@ YearPicker.defaultProps = {
 	...DEFAULT_PROPS,
 	min: 1900,
 	max: 2100,
-	placeholder: '请选择年份'
+	placeholder: 'yyyy'
 };

--- a/src/components/datepicker/year/main.js
+++ b/src/components/datepicker/year/main.js
@@ -3,17 +3,25 @@ import { ArrowLeft, ArrowRight } from '../common/arrow';
 import { displayNow } from '../utils';
 import YearGrid from './grid';
 
-export default class Popup extends Component {
+export default class Year extends Component {
 	constructor(props) {
 		super(props);
-
+		const { checkValue } = props;
 		this.state = {
-			region: this.getInitRegion()
+			checkValue,
+			region: this.getInitRegion(checkValue)
 		};
 	}
 
-	getInitRegion = () => {
-		const { min, max, checkValue } = this.props;
+	changeCheckValue = checkValue => {
+		this.setState({
+			checkValue,
+			region: this.getInitRegion(checkValue)
+		});
+	};
+
+	getInitRegion = checkValue => {
+		const { min, max } = this.props;
 		const year = checkValue ? parseInt(checkValue, 10) : displayNow().year;
 
 		if (year + 7 <= max || year - 7 >= min) {
@@ -38,8 +46,8 @@ export default class Popup extends Component {
 	};
 
 	render() {
-		const { region } = this.state;
-		const { min, max, checkValue } = this.props;
+		const { region, checkValue } = this.state;
+		const { min, max } = this.props;
 
 		const _checkYear = checkValue ? parseInt(checkValue, 10) : null;
 

--- a/src/components/field/demos/test-date.markdown
+++ b/src/components/field/demos/test-date.markdown
@@ -1,0 +1,96 @@
+---
+order: 3
+title: 测试日历组件
+desc: 测试
+---
+
+```javascript
+import React, { useState } from 'react';
+import { Form, Input, Button, Checkbox, Radio, Select, Toggle, InputNumber, Field, Datepicker } from 'cloud-react';
+
+export default function FormHorizontalDemo() {
+	const field = Field.useField();
+
+	const onValidate = () => {
+		field.validate((errs, values) => {
+			console.log(values);
+		});
+	};
+
+	const onReset = () => {
+		field.reset();
+	};
+
+	const { init } = field;
+
+	return (
+		<Form layout="horizontal" labelCol={{ span: 6 }} field={field}>
+                   <Form.Item label="年月日 时分秒">
+        				<Datepicker
+        					{...init('date1', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					maxDate={new Date('2024/5/1')}
+        					showTimePicker={true}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+        			<Form.Item label="年月日">
+        				<Datepicker
+        					{...init('date2', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					maxDate={new Date('2024/5/1')}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+        			<Form.Item label="年">
+        				<Datepicker.YearPicker
+        					{...init('date3', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+        			<Form.Item label="年月">
+        				<Datepicker.YearMonthPicker
+        					{...init('date4', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+        			<Form.Item label="月日">
+        				<Datepicker.MonthDayPicker
+        					{...init('date5', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+                      <Form.Item label="月日">
+        				<Datepicker.RangePicker
+        					{...init('date6', {
+        						rules: [{ required: true, message: '请输入时间' }]
+        					})}
+        					canEdit
+        				/>
+        			</Form.Item>
+
+
+        	<Form.Item wrapperCol={{ offset: 6 }}>
+        		<Button type="primary" style={{ marginRight: 10 }} onClick={onValidate}>
+        			提交
+        		</Button>
+        		<Button onClick={onReset}>重置</Button>
+        	</Form.Item>
+        </Form>
+
+	);
+}
+```


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [x] 新功能提交
-   [ ] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

需求背景：日历组件增加手动输入功能，更方便用户使用

解决方案

- 增加是否支持可输入配置字段，默认不可输入
- 手动输入的日期格式正确时，日历联动选中
- 手动输入的日期格式错误时，日历不联动选中（特殊情况：年月日 时分秒，当年月日格式正确时，日历会联动选中年月日）
- 可编辑的状态下，增加回车事件、失去焦点事件，将输入的日期抛出给业务端

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
