### PR TITLE
修复iframe下使用弹窗，会在父窗口head遗留style 影响其余样式

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -24,6 +24,12 @@ function insertRootDocumentStyleRule(doc) {
 	doc.head.appendChild(style);
 }
 
+function removeRootDocumentStyleRule(doc) {
+	const style = doc.querySelector(`[data-name="${sandboxSelector}"]`);
+
+	if (!style) return;
+	doc.head.removeChild(style);
+}
 class Notification extends Component {
 	constructor(props) {
 		super(props);
@@ -106,6 +112,7 @@ class Notification extends Component {
 
 	componentWillUnmount() {
 		this.window.removeEventListener('resize', this.screenChange);
+		this.removeRootDocumentStyleRule();
 	}
 
 	get window() {
@@ -141,6 +148,12 @@ class Notification extends Component {
 	insertRootDocumentStyleRule() {
 		if (window !== this.window) {
 			insertRootDocumentStyleRule(this.document);
+		}
+	}
+
+	removeRootDocumentStyleRule() {
+		if (window !== this.window) {
+			removeRootDocumentStyleRule(this.document);
 		}
 	}
 


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 readme，当前是从 master 拉取的分支。
2、请自己 merge 代码到 develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [x] 日常 bug 修复
-   [ ] 站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充或无须补充
-   [ ] 代码演示已提供或无须提供
