### PR TITLE
[Upload] 普通文件上传显示类型图标/onBeforeUpload支持异步函数/组件内部支持判断可选文件类型/ui优化

### DIFF
--- a/src/components/upload/constant.js
+++ b/src/components/upload/constant.js
@@ -1,8 +1,42 @@
 import { prefixCls } from '@utils';
 
 export const TYPE = {
-	PICTURE: 'picture',
-	DEFAULT: 'button'
+  PICTURE: 'picture',
+  DEFAULT: 'button',
 };
 
 export const PREFIX = `${prefixCls}-upload`;
+
+const FILE_TYPE_ICONS = {
+  csv: 'CSV',
+  video: 'video',
+  pdf: 'PDF',
+  ppt: 'PPT',
+  txt: 'TXT',
+  doc: 'DOC',
+  zip: 'ZIP',
+  xls: 'XLS',
+};
+
+const PIC_TYPES = [
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+];
+
+export const getFileTypeIcon = (file = {}) => {
+  const { name = '' } = file;
+  const _names = name.split('.');
+  const type = _names[_names.length - 1];
+
+  if (PIC_TYPES.includes(type)) {
+    return 'pic';
+  }
+
+  if (FILE_TYPE_ICONS[type]) {
+    return FILE_TYPE_ICONS[type];
+  }
+
+  return 'mr';
+};

--- a/src/components/upload/demos/basic-upload.md
+++ b/src/components/upload/demos/basic-upload.md
@@ -59,21 +59,22 @@ export default class UploadDemo extends React.Component {
 	render() {
 		const props = {
 			// type: 'picture',
-			limit: 1,
+			// limit: 1,
 			size: 2,
 			multiple: true,
 			isShowIcon: false,
 			hasPreview: false,
             showBeforeConfirm: true,
             params: {test: 1},
+			// style: { width: 66, height: 66 },
             beforeConfirmBody: (
                 <span>
                     请确定您要上传文件么？
                 </span>
             ),
 			labelText: '点击上传1',
-			headers: {},
-			action: '/upload',
+			headers: { 'x-token': 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0ZW5hbnRJZCI6InF5d3hfc3l5al93cG5UcndFQUFBV082cmtsWWVmUzBvc0VEenFSMTBQQSIsInVzZXJJZCI6MTE4NTA0NTIsInVzZXJUeXBlIjoicXl3eCIsInVzZXJOYW1lIjoid29uVHJ3RUFBQTFUZm9oRGFUajFhOVJZZlFtMnZFRFEiLCJleHQiOjE2NTIzNjI2NzMxMjAsImlhdCI6MTY1MjMxOTQ3MzEyMCwiY29ycElkIjoid3BuVHJ3RUFBQVdPNnJrbFllZlMwb3NFRHpxUjEwUEEiLCJidXNpbmVzc1VzZXJJZCI6IndvblRyd0VBQUExVGZvaERhVGoxYTlSWWZRbTJ2RURRIn0.ET-FRmvCgDGquMi_DnuRL4C56C58qzcn3Estk8Vq9j4' },
+			action: 'https://qa-ual.shuyun.com/pcrm-account/1.0/file/uploadImageFile',
 			onBeforeUpload(file) {
 				return true;
 			},

--- a/src/components/upload/demos/before-confirm.md
+++ b/src/components/upload/demos/before-confirm.md
@@ -1,18 +1,19 @@
 ---
-title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
-order: 1
-desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+title: 上传前显示确认对话框。
+order: 2
+desc: 上传前和用户进行确认，可配置具体提示内容。
 ---
 
 ```jsx
 /**
- * title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
- * desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+ * title: 上传前显示确认对话框。
+ * desc: 上传前和用户进行确认，可配置具体提示内容。
  */
 import React from 'react';
 import { Message, Upload } from 'cloud-react';
 
 export default class UploadDemo extends React.Component {
+
   state = {
     fileList: []
   };
@@ -64,23 +65,19 @@ export default class UploadDemo extends React.Component {
       labelText: '点击上传',
       headers: {},
       action: '/upload',
+      showBeforeConfirm: true,
+      beforeConfirmBody: <span>确认需要上传吗？</span>,
+      beforeConfirmConfig: {
+        title: '确定要上传文件吗？',
+        body: '这里是上传后响应状态的描述'
+      },
       onProgress: this.handleProgress,
       onSuccess: this.handleSuccess,
       onRemove: this.handleRemove,
       onReUpload: this.handleReUpload
     };
 
-    const minorBtnProps = {
-      type: 'normal'
-    };
-
-    return (
-      <div>
-        <Upload {...props} fileList={this.state.fileList} />
-        <br />
-        <Upload {...props} fileList={this.state.fileList} btnOptions={minorBtnProps} />
-      </div>
-    );
+    return <Upload {...props} fileList={this.state.fileList} />;
   }
 }
 ```

--- a/src/components/upload/demos/before-upload.md
+++ b/src/components/upload/demos/before-upload.md
@@ -1,18 +1,19 @@
 ---
-title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
-order: 1
-desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+title: 选中文件之后，上传前执行，可以控制是否继续上传。
+order: 8
+desc: 通过返回的boolean值来决定是否继续上传。
 ---
 
 ```jsx
 /**
- * title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
- * desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+ * title: 选中文件之后，上传前执行，可以控制是否继续上传。
+ * desc: 通过返回的boolean值来决定是否继续上传。
  */
 import React from 'react';
 import { Message, Upload } from 'cloud-react';
 
 export default class UploadDemo extends React.Component {
+
   state = {
     fileList: []
   };
@@ -64,23 +65,17 @@ export default class UploadDemo extends React.Component {
       labelText: '点击上传',
       headers: {},
       action: '/upload',
+      onBeforeUpload: () => {
+        Message.error('操作失败');
+        return false;
+      },
       onProgress: this.handleProgress,
       onSuccess: this.handleSuccess,
       onRemove: this.handleRemove,
       onReUpload: this.handleReUpload
     };
 
-    const minorBtnProps = {
-      type: 'normal'
-    };
-
-    return (
-      <div>
-        <Upload {...props} fileList={this.state.fileList} />
-        <br />
-        <Upload {...props} fileList={this.state.fileList} btnOptions={minorBtnProps} />
-      </div>
-    );
+    return <Upload {...props} fileList={this.state.fileList} />;
   }
 }
 ```

--- a/src/components/upload/demos/custom-request.md
+++ b/src/components/upload/demos/custom-request.md
@@ -1,6 +1,6 @@
 ---
 title: 自定义上传。
-order: 2
+order: 3
 desc: 根据自身业务需求，传相应FormData。
 ---
 

--- a/src/components/upload/demos/custom-upload.md
+++ b/src/components/upload/demos/custom-upload.md
@@ -1,6 +1,6 @@
 ---
 title: 自定义上传显示
-order: 6
+order: 7
 desc: 自定义上传显示。
 ---
 

--- a/src/components/upload/demos/file-list-picture.md
+++ b/src/components/upload/demos/file-list-picture.md
@@ -1,6 +1,6 @@
 ---
 title: 图片形式已上传列表
-order: 5
+order: 6
 desc: 使用 fileList 设置已上传的图片列表进行控制。
 ---
 

--- a/src/components/upload/demos/file-list-text.md
+++ b/src/components/upload/demos/file-list-text.md
@@ -1,6 +1,6 @@
 ---
 title: 已上传的文件列表
-order: 4
+order: 5
 desc: 使用 fileList 设置已上传的文件列表。
 ---
 

--- a/src/components/upload/demos/file-list-text.md
+++ b/src/components/upload/demos/file-list-text.md
@@ -6,10 +6,10 @@ desc: 使用 fileList 设置已上传的文件列表。
 
 ```jsx
 
-            /**
-             * title: 已上传的文件列表
-             * desc: 使用 fileList 设置已上传的文件列表。
-             */
+/**
+ * title: 已上传的文件列表
+ * desc: 使用 fileList 设置已上传的文件列表。
+ */
 import React from 'react';
 import { Message, Upload } from 'cloud-react';
 
@@ -18,20 +18,35 @@ export default class UploadDemo extends React.Component {
 		fileList: [
 			{
 				id: '1',
-				name: 'xxx.png',
-				url: 'http://www.baidu.com/xxx.png'
+				name: '头像哎.png',
+				url: 'http://wework.qpic.cn/bizmail/VtA3epsUIvNIEUSja4VNWy3a0tWLCEiajSFOBFicBQRosvss0SyZ7t2w/0'
 			},
 			{
 				id: '2',
-				name: 'yyy.png',
-				url: 'http://www.baidu.com/yyy.png'
+				name: 'yyy.xls',
+				url: 'http://www.baidu.com/yyy.xls'
 			},
 			{
 				id: '3',
-				name: 'zzz.png',
-				url: 'http://www.baidu.com/zzz.png',
+				name: '已上传的文件列表已上传的文件列表已上传的文件列表已上传的文件列表已上传的文件列表xxx.csv',
+				url: 'http://www.baidu.com/zzz.csv',
 				status: 'error'
-			}
+			},
+			{
+				id: '4',
+				name: 'zzz.txt',
+				url: 'http://www.baidu.com/zzz.txt'
+			},
+			{
+				id: '5',
+				name: '已上传的文件列表已上传的文件列表已上传的文件列表已上传的文件列表已上传的文件列表xxx.jpg',
+				url: 'https://qa-pcrm.shuyun.com/pcrm/202206/e2f5f56627cbabf6e6790fe70503cefe/155512_44787_规则标题@2x.jpg'
+			},
+			{
+				id: '6',
+				name: '未知文件类型.xlsx',
+				url: '未知文件类型.xlsx'
+			},
 		]
 	};
 

--- a/src/components/upload/demos/picture.md
+++ b/src/components/upload/demos/picture.md
@@ -1,6 +1,6 @@
 ---
 title: 图片形式上传
-order: 3
+order: 4
 desc: 设置 type=picture 样式上传，并且处理上传失败 onError 的情况。
 ---
 

--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -398,6 +398,7 @@ class Upload extends Component {
         />
         {isShowPreview && (
           <Modal
+            modalStyle={{ width: 680, height: 680 }}
             hasFooter={false}
             className={`${PREFIX}-pic-preview`}
             title={name}

--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -73,7 +73,7 @@ class Upload extends Component {
   onClick = (e) => {
     const element = this.ref.current;
     if (!element || e?.target === element) return;
-    const { onClick, showBeforeConfirm, beforeConfirmBody } = this.props;
+    const { onClick, showBeforeConfirm, beforeConfirmBody, beforeConfirmConfig } = this.props;
 
     onClick().then(() => {
       if (!showBeforeConfirm) {
@@ -81,7 +81,9 @@ class Upload extends Component {
         return;
       }
       Modal.confirm({
+        icon: 'info_1',
         body: beforeConfirmBody,
+        ...beforeConfirmConfig,
         onOk: () => {
           element.click();
         },
@@ -456,6 +458,7 @@ Upload.propTypes = {
   hasPreview: PropTypes.bool,
   showBeforeConfirm: PropTypes.bool,
   beforeConfirmBody: PropTypes.node,
+  beforeConfirmConfig: PropTypes.object,
   customRequest: PropTypes.func,
   onClick: PropTypes.func,
   onBeforeUpload: PropTypes.func,
@@ -486,6 +489,9 @@ Upload.defaultProps = {
   customRequest: undefined,
   showBeforeConfirm: false,
   beforeConfirmBody: '确认上传？',
+  beforeConfirmConfig: {
+    title: '确定要上传文件吗？',
+  },
   onClick: () => new Promise((resolve) => resolve()),
   onBeforeUpload: undefined,
   onProgress: noop,

--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -14,482 +14,488 @@ import { TYPE, PREFIX } from './constant';
 
 import './index.less';
 
-const Text = props => {
-	const { isShowIcon, labelText, disabled, options } = props;
-	return (
-		<Button type="primary" disabled={disabled} {...options}>
-			{isShowIcon && <Icon type="upload" style={{ fontSize: '14px', marginRight: '8px' }} />}
-			<span>{labelText}</span>
-		</Button>
-	);
+const Text = (props) => {
+  const {
+    isShowIcon, labelText, disabled, options,
+  } = props;
+  return (
+    <Button type="primary" disabled={disabled} {...options}>
+      {isShowIcon && <Icon type="upload" style={{ fontSize: '16px', marginRight: '8px' }} />}
+      <span>{labelText}</span>
+    </Button>
+  );
 };
 
-const Picture = props => {
-	const { labelText } = props;
-	return (
-		<div>
-			<Icon type="plus" style={{ fontSize: '16px' }} />
-			<div className={`${PREFIX}-text`}>{labelText}</div>
-		</div>
-	);
+const Picture = (props) => {
+  const { labelText } = props;
+  return (
+    <div>
+      <Icon type="plus" style={{ fontSize: '16px' }} />
+      <div className={`${PREFIX}-text`}>{labelText}</div>
+    </div>
+  );
 };
 
 class Upload extends Component {
-	requests = {};
+  requests = {};
 
-	defaultFileList = [];
+  defaultFileList = [];
 
-	constructor(props) {
-		super(props);
+  constructor(props) {
+    super(props);
 
-		this.ref = createRef();
+    this.ref = createRef();
 
-		const list = props.fileList || this.defaultFileList;
-		this.state = {
-			fileList: [...list],
-			selectPic: {},
-			isShowPreview: false,
-			prevFileList: [...list],
-		};
-	}
+    const list = props.fileList || this.defaultFileList;
+    this.state = {
+      fileList: [ ...list ],
+      selectPic: {},
+      isShowPreview: false,
+      prevFileList: [ ...list ],
+    };
+  }
 
-	static getDerivedStateFromProps(props, prevState) {
-		const { fileList } = props;
-		if (props.fileList && !ShuyunUtils.equal(fileList, prevState.prevFileList)) {
-			return {
-				fileList: [...fileList],
-				prevFileList: [...fileList] 
-			};
-		}
-		return null;
-	}
+  static getDerivedStateFromProps(props, prevState) {
+    const { fileList } = props;
+    if (props.fileList && !ShuyunUtils.equal(fileList, prevState.prevFileList)) {
+      return {
+        fileList: [ ...fileList ],
+        prevFileList: [ ...fileList ] 
+      };
+    }
+    return null;
+  }
 
-	componentWillUnmount() {
-		this.abort();
-	}
+  componentWillUnmount() {
+    this.abort();
+  }
 
-	onClick = e => {
-		const element = this.ref.current;
-		if (!element || e?.target === element) return;
-		const { onClick, showBeforeConfirm, beforeConfirmBody } = this.props;
+  onClick = (e) => {
+    const element = this.ref.current;
+    if (!element || e?.target === element) return;
+    const { onClick, showBeforeConfirm, beforeConfirmBody } = this.props;
 
-		onClick().then(() => {
-			if (!showBeforeConfirm) {
-				element.click();
-				return;
-			}
-			Modal.confirm({
-				body: beforeConfirmBody,
-				onOk: () => {
-					element.click();
-				}
-			});
-		});
-	};
+    onClick().then(() => {
+      if (!showBeforeConfirm) {
+        element.click();
+        return;
+      }
+      Modal.confirm({
+        body: beforeConfirmBody,
+        onOk: () => {
+          element.click();
+        },
+      });
+    });
+  };
 
-	getFileList() {
-		return this.ref.current.files;
-	}
+  getFileList() {
+    return this.ref.current.files;
+  }
 
-	handlePreview = (item = {}) => {
-		this.setState({
-			selectPic: item,
-			isShowPreview: !!item.url
-		});
-	}
+  handlePreview = (item = {}) => {
+    this.setState({
+      selectPic: item,
+      isShowPreview: !!item.url,
+    });
+  }
 
-	handleChange = () => {
-		// 已选择文件数量校验，如果没有选择文件的时候不允许点击上传按钮
-		const number = this.getFileList().length;
-		const { limit } = this.props;
+  handleChange = () => {
+    // 已选择文件数量校验，如果没有选择文件的时候不允许点击上传按钮
+    const number = this.getFileList().length;
+    const { limit } = this.props;
 
-		if (number === 0) return;
+    if (number === 0) return;
 
-		if (limit && limit !== 1 && this.state.fileList.length + number > limit) {
-			Message.error(`最多上传${limit}个`);
-			return;
-		}
+    if (limit && limit !== 1 && this.state.fileList.length + number > limit) {
+      Message.error(`最多上传${limit}个`);
+      return;
+    }
 
-		this.handleUpload();
-	};
+    this.handleUpload();
+  };
 
-	handleUpload = () => {
-		const fileList = this.getFileList();
+  handleUpload = () => {
+    const fileList = this.getFileList();
 
-		const newFileList = [...Array.from(fileList)].map(file => {
-			// file 为是一个特殊上传 File 对象，此处无法使用结构的方式来处理
-			const item = file;
-			item.id = getUuid();
-			return item;
-		});
-		this.upload(newFileList);
-	};
+    const newFileList = [ ...Array.from(fileList) ].map((file) => {
+      // file 为是一个特殊上传 File 对象，此处无法使用结构的方式来处理
+      const item = file;
+      item.id = getUuid();
+      return item;
+    });
+    this.upload(newFileList);
+  };
 
-	handleReUpload = item => {
-		this.setState({
-			selectPic: item
-		});
+  handleReUpload = (item) => {
+    this.setState({
+      selectPic: item,
+    });
 
-		this.onClick();
-	}
+    this.onClick();
+  }
 
-	handleRemove = file => {
-		const { onRemove } = this.props;
+  handleRemove = (file) => {
+    const { onRemove } = this.props;
 
-		onRemove({
-			file,
-			fileList: [...this.state.fileList]
-		});
-	};
+    onRemove({
+      file,
+      fileList: [ ...this.state.fileList ]
+    });
+  };
 
-	handleProgress = (event, file) => {
-		const { onProgress } = this.props;
-		const newFile = this.getStatusFile(file, 'uploading', event.percent);
+  handleProgress = (event, file) => {
+    const { onProgress } = this.props;
+    const newFile = this.getStatusFile(file, 'uploading', event.percent);
 
-		onProgress({
-			file: newFile,
-			fileList: [...this.state.fileList],
-			percent: event.percent
-		});
-	};
+    onProgress({
+      file: newFile,
+      fileList: [ ...this.state.fileList ],
+      percent: event.percent,
+    });
+  };
 
-	getStatusFile = (file, status, percent) => {
-		const { selectPic } = this.state;
-		const newFile = [...Array.from([file])].map(file => {
-			const item = file;
-			item.status = status;
-			if (percent) {
-				item.percent = percent;
-			}
-			if (selectPic.url) {
-				item.index = selectPic.index;
-			}
-			return item;
-		});
-		return newFile[0];
-	}
+  getStatusFile = (file, status, percent) => {
+    const { selectPic } = this.state;
+    const newFile = [ ...Array.from([ file ]) ].map((v) => {
+      const item = v;
+      item.status = status;
+      if (percent) {
+        item.percent = percent;
+      }
+      if (selectPic.url) {
+        item.index = selectPic.index;
+      }
+      return item;
+    });
+    return newFile[0];
+  }
 
-	handleSuccess = (response, file) => {
-		try {
-			if (typeof response === 'string') {
-				// eslint-disable-next-line
-				response = JSON.parse(response);
-			}
-		} catch (e) {
-			console.warn(e);
-		}
+  handleSuccess = (response, file) => {
+    try {
+      if (typeof response === 'string') {
+        // eslint-disable-next-line
+        response = JSON.parse(response);
+      }
+    } catch (e) {
+      console.warn(e);
+    }
 
-		const { onSuccess, onReUpload } = this.props;
-		const { selectPic } = this.state;
-		this.ref.current.value = '';
-		const newFile = this.getStatusFile(file, 'done');
-		if (selectPic.url) {
-			onReUpload({
-				file: newFile,
-				fileList: [...this.state.fileList],
-				response
-			});
-			this.setState({
-				selectPic: {}
-			});
-			return;
-		}
-		onSuccess({
-			file: newFile,
-			fileList: [...this.state.fileList],
-			response
-		});
-	};
+    const { onSuccess, onReUpload } = this.props;
+    const { selectPic } = this.state;
+    this.ref.current.value = '';
+    const newFile = this.getStatusFile(file, 'done');
+    if (selectPic.url) {
+      onReUpload({
+        file: newFile,
+        fileList: [ ...this.state.fileList ],
+        response,
+      });
+      this.setState({
+        selectPic: {},
+      });
+      return;
+    }
+    onSuccess({
+      file: newFile,
+      fileList: [ ...this.state.fileList ],
+      response,
+    });
+  };
 
-	handleError = (error, file) => {
-		const { onError } = this.props;
-		this.ref.current.value = '';
-		const newFile = this.getStatusFile(file, 'error');
-		if (this.state.selectPic.url) {
-			this.setState({
-				selectPic: {}
-			});
-		}
-		onError({
-			file: newFile,
-			fileList: [...this.state.fileList],
-			error
-		});
-	};
+  handleError = (error, file) => {
+    const { onError } = this.props;
+    this.ref.current.value = '';
+    const newFile = this.getStatusFile(file, 'error');
+    if (this.state.selectPic.url) {
+      this.setState({
+        selectPic: {},
+      });
+    }
+    onError({
+      file: newFile,
+      fileList: [ ...this.state.fileList ],
+      error,
+    });
+  };
 
-	/**
-	 * 文件上传之前校验大小是否符合
-	 */
-	handleBeforeUpload(file) {
-		const { size, unit } = this.props;
+  /**
+   * 文件上传之前校验大小是否符合
+   */
+  handleBeforeUpload(file) {
+    const { size, unit } = this.props;
 
-		let isSizeInvalidate;
+    let isSizeInvalidate;
 
-		if (unit === 'M') {
-			isSizeInvalidate = file.size / 1024 / 1024 > size;
-		}
+    if (unit === 'M') {
+      isSizeInvalidate = file.size / 1024 / 1024 > size;
+    }
 
-		if (unit === 'KB') {
-			isSizeInvalidate = file.size / 1024 > size;
-		}
+    if (unit === 'KB') {
+      isSizeInvalidate = file.size / 1024 > size;
+    }
 
-		if (isSizeInvalidate) {
-			Message.error(`文件过大，最大支持 ${size} ${unit} 的文件上传！`);
-			this.ref.current.value = '';
-			return false;
-		}
+    if (isSizeInvalidate) {
+      Message.error(`文件过大，最大支持 ${size} ${unit} 的文件上传！`);
+      this.ref.current.value = '';
+      return false;
+    }
 
-		if (this.props.onBeforeUpload) {
-			return this.props.onBeforeUpload(file);
-		}
+    if (this.props.onBeforeUpload) {
+      return this.props.onBeforeUpload(file);
+    }
 
-		return true;
-	}
+    return true;
+  }
 
-	upload(file) {
-		const { unify } = this.props;
-		if (unify) {
-			const sizeValidate = file.filter(item => this.handleBeforeUpload(item));
-			if (file.length === sizeValidate.length) {
-				this.post(file);
-			}
-		} else {
-			file.forEach(fileItem => {
-				const before = this.handleBeforeUpload(fileItem);
-				if (before) {
-					this.post(fileItem);
-				}
-			});
-		}
-	}
+  upload(file) {
+    const { unify } = this.props;
+    if (unify) {
+      const sizeValidate = file.filter((item) => this.handleBeforeUpload(item));
+      if (file.length === sizeValidate.length) {
+        this.post(file);
+      }
+    } else {
+      file.forEach((fileItem) => {
+        const before = this.handleBeforeUpload(fileItem);
+        if (before) {
+          this.post(fileItem);
+        }
+      });
+    }
+  }
 
-	post = file => {
-		const { action, headers, withCredentials, customRequest, unify, params } = this.props;
-		const request = customRequest || defaultHttp;
-		const { id } = file;
-		const option = {
-			action,
-			params,
-			filename: file.name,
-			file,
-			headers,
-			withCredentials,
-			unify,
-			onProgress: event => {
-				this.handleProgress(event, file);
-			},
-			onSuccess: (response, xhr) => {
-				delete this.requests[id];
-				this.handleSuccess(response, file, xhr);
-			},
-			onError: error => {
-				delete this.requests[id];
-				this.handleError(error, file);
-			}
-		};
-		this.requests[id] = request(option);
-	}
+  post = (file) => {
+    const {
+      action, headers, withCredentials, customRequest, unify, params
+    } = this.props;
+    const request = customRequest || defaultHttp;
+    const { id } = file;
+    const option = {
+      action,
+      params,
+      filename: file.name,
+      file,
+      headers,
+      withCredentials,
+      unify,
+      onProgress: (event) => {
+        this.handleProgress(event, file);
+      },
+      onSuccess: (response, xhr) => {
+        delete this.requests[id];
+        this.handleSuccess(response, file, xhr);
+      },
+      onError: (error) => {
+        delete this.requests[id];
+        this.handleError(error, file);
+      },
+    };
+    this.requests[id] = request(option);
+  }
 
-	abort() {
-		Object.keys(this.requests).forEach(id => {
-			const req = this.requests[id];
-			if (req && req.abort) {
-				req.abort();
-			}
+  abort() {
+    Object.keys(this.requests).forEach((id) => {
+      const req = this.requests[id];
+      if (req && req.abort) {
+        req.abort();
+      }
 
-			delete this.requests[id];
-		});
-	}
+      delete this.requests[id];
+    });
+  }
 
-	renderUploadShow() {
-		const { type, children, labelText, isShowIcon, btnOptions, disabled } = this.props;
+  renderUploadShow() {
+    const {
+      type, children, labelText, isShowIcon, btnOptions, disabled
+    } = this.props;
 
-		if (children) return children;
+    if (children) return children;
 
-		if (type === TYPE.DEFAULT) {
-			return (
-				<Text
-					options={btnOptions}
-					labelText={labelText}
-					disabled={disabled}
-					isShowIcon={isShowIcon}
-				/>
-			);
-		}
-		return <Picture disabled={disabled} labelText={labelText} />;
-	}
+    if (type === TYPE.DEFAULT) {
+      return (
+        <Text
+          options={btnOptions}
+          labelText={labelText}
+          disabled={disabled}
+          isShowIcon={isShowIcon}
+        />
+      );
+    }
+    return <Picture disabled={disabled} labelText={labelText} />;
+  }
 
-	renderUpload() {
-		const { type, accept, disabled, multiple, className, limit } = this.props;
-		const { fileList } = this.state;
-		const uploadDisabled = disabled || limit && limit > 1 && limit === fileList.length;
+  renderUpload() {
+    const {
+      type, accept, disabled, multiple, className, limit
+    } = this.props;
+    const { fileList } = this.state;
+    const uploadDisabled = disabled || limit && limit > 1 && limit === fileList.length;
 
-		const classes = classNames(
-			PREFIX,
-			{
-				[`${PREFIX}-select`]: true,
-				[`${PREFIX}-select-${type}`]: true,
-				[`${PREFIX}-disabled`]: uploadDisabled
-			},
-			className
-		);
+    const classes = classNames(
+      PREFIX,
+      {
+        [`${PREFIX}-select`]: true,
+        [`${PREFIX}-select-${type}`]: true,
+        [`${PREFIX}-disabled`]: uploadDisabled,
+      },
+      className,
+    );
 
-		const events = uploadDisabled
-			? {}
-			: {
-					onClick: this.onClick
-			  };
+    const events = uploadDisabled
+      ? {}
+      : { onClick: this.onClick };
 
-		if (limit === 1 && fileList.length) {
-			return (
-				<input
-					style={{ display: 'none' }}
-					type="file"
-					disabled={uploadDisabled}
-					ref={this.ref}
-					accept={accept}
-					multiple={multiple}
-					onChange={this.handleChange}
-				/>
-			)
-		}
+    if (limit === 1 && fileList.length) {
+      return (
+        <input
+          style={{ display: 'none' }}
+          type="file"
+          disabled={uploadDisabled}
+          ref={this.ref}
+          accept={accept}
+          multiple={multiple}
+          onChange={this.handleChange}
+        />
+      );
+    }
 
-		return (
-			<div className={classes}>
-				<span className={PREFIX} role="button" {...events}>
-					<input
-						style={{ display: 'none' }}
-						type="file"
-						disabled={uploadDisabled}
-						ref={this.ref}
-						accept={accept}
-						multiple={multiple}
-						onChange={this.handleChange}
-					/>
-					{this.renderUploadShow()}
-				</span>
-			</div>
-		);
-	};
+    return (
+      <div className={classes}>
+        <span className={PREFIX} role="button" {...events}>
+          <input
+            style={{ display: 'none' }}
+            type="file"
+            disabled={uploadDisabled}
+            ref={this.ref}
+            accept={accept}
+            multiple={multiple}
+            onChange={this.handleChange}
+          />
+          {this.renderUploadShow()}
+        </span>
+      </div>
+    );
+  }
 
-	renderPicture() {
-		const { type, hasPreview, disabled } = this.props;
-		const { fileList, selectPic, isShowPreview } = this.state;
-		const { name, url } = selectPic;
+  renderPicture() {
+    const { type, hasPreview, disabled } = this.props;
+    const { fileList, selectPic, isShowPreview } = this.state;
+    const { name, url } = selectPic;
 
-		return (
-			<>
-				<UploadList
-					disabled={disabled}
-					type={type}
-					fileList={fileList}
-					hasPreview={hasPreview}
-					onRemove={this.handleRemove}
-					onPreview={this.handlePreview}
-					onReUpload={this.handleReUpload}
-				/>
-				{isShowPreview && (
-					<Modal
-						hasFooter={false}
-						className={`${PREFIX}-pic-preview`}
-						title={name}
-						visible={isShowPreview}
-						onClose={() => this.handlePreview()}
-					>
-						<img src={url} alt="" />
-					</Modal>
-				)}
-				{this.renderUpload()}
-			</>
-		)
-	}
+    return (
+      <>
+        <UploadList
+          disabled={disabled}
+          type={type}
+          fileList={fileList}
+          hasPreview={hasPreview}
+          onRemove={this.handleRemove}
+          onPreview={this.handlePreview}
+          onReUpload={this.handleReUpload}
+        />
+        {isShowPreview && (
+          <Modal
+            hasFooter={false}
+            className={`${PREFIX}-pic-preview`}
+            title={name}
+            visible={isShowPreview}
+            onClose={() => this.handlePreview()}
+          >
+            <img src={url} alt="" />
+          </Modal>
+        )}
+        {this.renderUpload()}
+      </>
+    );
+  }
 
-	renderNormal() {
-		const { type, disabled } = this.props;
-		const { fileList } = this.state;
-		return (
-			<>
-				{this.renderUpload()}
-				<UploadList disabled={disabled} type={type} fileList={fileList} onRemove={this.handleRemove} />
-			</>
-		)
-	}
+  renderNormal() {
+    const { type, disabled } = this.props;
+    const { fileList } = this.state;
+    return (
+      <>
+        {this.renderUpload()}
+        <UploadList disabled={disabled} type={type} fileList={fileList} onRemove={this.handleRemove} />
+      </>
+    );
+  }
 
-	render() {
-		const { type, children } = this.props;
+  render() {
+    const { type, children } = this.props;
 
-		if (children) {
-			return (
-				<div className={`${PREFIX}-${type}-wrapper`}>
-					{this.renderUpload()}
-				</div>
-			); 
-		}
+    if (children) {
+      return (
+        <div className={`${PREFIX}-${type}-wrapper`}>
+          {this.renderUpload()}
+        </div>
+      );
+    }
 
-		return (
-			<div className={`${PREFIX}-${type}-wrapper`}>
-				{type === TYPE.PICTURE ? this.renderPicture() : this.renderNormal()}
-			</div>
-		);
-	}
+    return (
+      <div className={`${PREFIX}-${type}-wrapper`}>
+        {type === TYPE.PICTURE ? this.renderPicture() : this.renderNormal()}
+      </div>
+    );
+  }
 }
 
 Upload.propTypes = {
-	type: PropTypes.oneOf([TYPE.PICTURE, TYPE.DEFAULT]),
-	btnOptions: PropTypes.object,
-	labelText: PropTypes.string,
-	accept: PropTypes.string,
-	size: PropTypes.number,
-	unit: PropTypes.string,
-	limit: PropTypes.number,
-	disabled: PropTypes.bool,
-	fileList: PropTypes.array,
-	action: PropTypes.string,
-	multiple: PropTypes.bool,
-	isShowIcon: PropTypes.bool,
-	hasPreview: PropTypes.bool,
-	showBeforeConfirm: PropTypes.bool,
-	beforeConfirmBody: PropTypes.node,
-	customRequest: PropTypes.func,
-	onClick: PropTypes.func,
-	onBeforeUpload: PropTypes.func,
-	onProgress: PropTypes.func,
-	onSuccess: PropTypes.func,
-	onError: PropTypes.func,
-	onReUpload: PropTypes.func,
-	onRemove: PropTypes.func,
-	className: PropTypes.string,
-	unify: PropTypes.bool,
-	params: PropTypes.object
+  type: PropTypes.oneOf([ TYPE.PICTURE, TYPE.DEFAULT ]),
+  btnOptions: PropTypes.object,
+  labelText: PropTypes.string,
+  accept: PropTypes.string,
+  size: PropTypes.number,
+  unit: PropTypes.string,
+  limit: PropTypes.number,
+  disabled: PropTypes.bool,
+  fileList: PropTypes.array,
+  action: PropTypes.string,
+  multiple: PropTypes.bool,
+  isShowIcon: PropTypes.bool,
+  hasPreview: PropTypes.bool,
+  showBeforeConfirm: PropTypes.bool,
+  beforeConfirmBody: PropTypes.node,
+  customRequest: PropTypes.func,
+  onClick: PropTypes.func,
+  onBeforeUpload: PropTypes.func,
+  onProgress: PropTypes.func,
+  onSuccess: PropTypes.func,
+  onError: PropTypes.func,
+  onReUpload: PropTypes.func,
+  onRemove: PropTypes.func,
+  className: PropTypes.string,
+  unify: PropTypes.bool,
+  params: PropTypes.object,
 };
 
 Upload.defaultProps = {
-	type: TYPE.DEFAULT,
-	btnOptions: {},
-	labelText: '选择文件',
-	accept: '*',
-	size: 1,
-	unit: 'M',
-	limit: null,
-	disabled: false,
-	fileList: undefined,
-	action: '',
-	multiple: false,
-	isShowIcon: true,
-	hasPreview: true,
-	customRequest: undefined,
-	showBeforeConfirm: false,
-	beforeConfirmBody: '确认上传？',
-	onClick: () => new Promise(resolve => resolve()),
-	onBeforeUpload: undefined,
-	onProgress: noop,
-	onSuccess: noop,
-	onError: noop,
-	onReUpload: noop,
-	onRemove: noop,
-	className: '',
-	unify: false,
-	params: {}
+  type: TYPE.DEFAULT,
+  btnOptions: {},
+  labelText: '选择文件',
+  accept: '*',
+  size: 1,
+  unit: 'M',
+  limit: null,
+  disabled: false,
+  fileList: undefined,
+  action: '',
+  multiple: false,
+  isShowIcon: true,
+  hasPreview: true,
+  customRequest: undefined,
+  showBeforeConfirm: false,
+  beforeConfirmBody: '确认上传？',
+  onClick: () => new Promise((resolve) => resolve()),
+  onBeforeUpload: undefined,
+  onProgress: noop,
+  onSuccess: noop,
+  onError: noop,
+  onReUpload: noop,
+  onRemove: noop,
+  className: '',
+  unify: false,
+  params: {},
 };
 
 export default Upload;

--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -245,10 +245,14 @@ class Upload extends Component {
       return false;
     }
 
-    if (accept !== '*' && !accept.includes(file.type)) {
-      Message.error(`仅支持上传${accept}格式的文件`);
-      this.ref.current.value = '';
-      return false;
+    if (accept !== '*') {
+      const fileNames = file.name.split('.') || [];
+      const fileType = `.${fileNames[fileNames.length - 1]}`;
+      if (!accept.includes(file.type) && !accept.includes(fileType)) {
+        Message.error(`仅支持上传${accept}格式的文件`);
+        this.ref.current.value = '';
+        return false;
+      }
     }
 
     if (onBeforeUpload) {
@@ -462,7 +466,7 @@ Upload.propTypes = {
   type: PropTypes.oneOf([ TYPE.PICTURE, TYPE.DEFAULT ]),
   btnOptions: PropTypes.object,
   labelText: PropTypes.string,
-  accept: PropTypes.string,
+  accept: PropTypes.oneOfType([ PropTypes.array, PropTypes.string ]),
   size: PropTypes.number,
   unit: PropTypes.string,
   limit: PropTypes.number,

--- a/src/components/upload/index.less
+++ b/src/components/upload/index.less
@@ -82,8 +82,11 @@
 	}
 
 	&-pic-preview {
-		img {
-			width: 100%;
+		&-detail {
+			height: 590px;
+			background-repeat: no-repeat;
+			background-size: contain;
+			background-position: center;
 		}
 	}
 

--- a/src/components/upload/index.less
+++ b/src/components/upload/index.less
@@ -113,6 +113,7 @@
 
 		.@{upload-prefix-cls}-list-delete {
 			position: relative;
+			cursor: pointer;
 			background: @gray-4;
 			width: 14px;
 			height: 14px;
@@ -167,12 +168,13 @@
 				column-gap: 16px;
 
 				&-detail {
-					width: 28px;
-					height: 28px;
-					flex-basis: 28px;
+					width: 32px;
+					height: 32px;
+					flex-basis: 32px;
 
 					> img {
-						max-width: 28px;
+						max-width: 32px;
+						border-radius: 2px;
 					}
 				}
 			}
@@ -183,7 +185,7 @@
 		}
 
 		&-type-icon {
-			font-size: 28px;
+			font-size: 32px;
 		}
 
 		&-pic {
@@ -228,7 +230,7 @@
 				.@{upload-prefix-cls}-list-delete {
 					position: absolute;
 					top: -16px;
-					right: -13px;
+					right: -16px;
 				}
 			}
 

--- a/src/components/upload/index.less
+++ b/src/components/upload/index.less
@@ -144,7 +144,7 @@
 			color: @gray-9;
 
 			&:first-child {
-				margin-top: 8px;
+				margin-top: 4px;
 			}
 
 			&:hover {
@@ -158,6 +158,31 @@
 			&-error {
 				color: @red-4;
 			}
+
+			&-info {
+				// max-width: 300px;
+				display: flex;
+				align-items: center;
+				column-gap: 16px;
+
+				&-detail {
+					width: 28px;
+					height: 28px;
+					flex-basis: 28px;
+
+					> img {
+						max-width: 28px;
+					}
+				}
+			}
+
+			&-name {
+				.text-overflow-ellipsis();
+			}
+		}
+
+		&-type-icon {
+			font-size: 28px;
 		}
 
 		&-pic {

--- a/src/components/upload/index.less
+++ b/src/components/upload/index.less
@@ -139,6 +139,7 @@
 			height: 54px;
 			padding: 16px;
 			margin-top: 4px;
+			border-radius: 2px;
 			font-size: @size-big;
 			box-sizing: border-box;
 			color: @gray-9;

--- a/src/components/upload/index.md
+++ b/src/components/upload/index.md
@@ -34,7 +34,8 @@ group:
 | multiple          | 是否上传多个文件                                                | boolean     | false                        |
 | isShowIcon        | 是否显示上传按钮前面的图标                                      | boolean     | true                         |
 | showBeforeConfirm | 上传前是否显示确认对话框                                        | boolean     | false                        |
-| beforeConfirmBody | 上传前的确认对话框中的提示信息                                  | any         | '确认上传吗?'                |
+| beforeConfirmBody | 上传前的确认对话框中的提示描述，如只需配置提示描述可使用此参数         | any         | '确认上传吗?'                |
+| beforeConfirmConfig | 上传前的确认对话框的配置信息，相关配置信息可参考Modal.confirm     | any         | { title: '确定要上传文件吗？' }                |
 | onClick           | 返回Promise对像，当未执行resolve()时将中止上传  | func | () => new Promise(resolve => resolve())  |
 | onBeforeUpload    | 选中文件之后，上传前执行，通过返回的boolean值来决定是否继续上传   | func        |                              |
 | customRequest     | 自定义上传                                                      | func        |                              |
@@ -123,6 +124,10 @@ group:
  ### 代码演示 
 
 <embed src="@components/upload/demos/basic-upload.md" /> 
+
+<embed src="@components/upload/demos/before-confirm.md" /> 
+
+<embed src="@components/upload/demos/before-upload.md" /> 
 
 <embed src="@components/upload/demos/custom-request.md" /> 
 

--- a/src/components/upload/index.md
+++ b/src/components/upload/index.md
@@ -36,6 +36,7 @@ group:
 | showBeforeConfirm | 上传前是否显示确认对话框                                        | boolean     | false                        |
 | beforeConfirmBody | 上传前的确认对话框中的提示描述，如只需配置提示描述可使用此参数         | any         | '确认上传吗?'                |
 | beforeConfirmConfig | 上传前的确认对话框的配置信息，相关配置信息可参考Modal.confirm     | any         | { title: '确定要上传文件吗？' }                |
+| unify             | 是否一次性上传多个文件                                                | boolean     | false                        |
 | onClick           | 返回Promise对像，当未执行resolve()时将中止上传  | func | () => new Promise(resolve => resolve())  |
 | onBeforeUpload    | 选中文件之后，上传前执行，通过返回的boolean值来决定是否继续上传   | func        |                              |
 | customRequest     | 自定义上传                                                      | func        |                              |

--- a/src/components/upload/list.js
+++ b/src/components/upload/list.js
@@ -54,16 +54,14 @@ const TextItem = ({ item, disabled, onRemove }) => {
           )}
         </div>
         {!disabled && (
-          <div className={`${prefix}-text-actions`}>
-            <div className={`${prefix}-delete`}>
-              <Icon
-                type="close"
-                style={{ fontSize: '14px' }}
-                onClick={() => {
-                  onRemove(item);
-                }}
-              />
-            </div>
+          <div className={`${prefix}-delete`}>
+            <Icon
+              type="close"
+              style={{ fontSize: '14px' }}
+              onClick={() => {
+                onRemove(item);
+              }}
+            />
           </div>
         )}
       </div>
@@ -114,7 +112,7 @@ const Picture = (props) => {
           {hasPreview && (
             <Icon
               type="view"
-              style={{ fontSize: '17px', marginRight: disabled ? 0 : 18 }}
+              style={{ fontSize: '16px', marginRight: disabled ? 0 : 16 }}
               onClick={() => {
                 onPreview(item);
               }}
@@ -124,7 +122,7 @@ const Picture = (props) => {
             <>
               <Icon
                 type="edit"
-                style={{ fontSize: '14px' }}
+                style={{ fontSize: '16px' }}
                 onClick={() => {
                   onReUpload({ ...item, index });
                 }}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [ ] bugfix

### 💡 需求背景和解决方案

1.ui优化
2.onBeforeUpload新增支持异步函数
3.组件内部支持判断可选文件类型

### 📝 更新日志怎么写？

1.onBeforeUpload新增支持异步函数
2.新增普通文件上传显示类型图标
3.组件内部支持判断可选文件类型
4.部分ui优化

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充
