### PR TITLE
[Upload] 普通文件上传显示类型图标/onBeforeUpload支持异步函数/组件内部支持判断可选文件类型/ui优化

### DIFF
--- a/src/components/upload/demos/before-confirm.md
+++ b/src/components/upload/demos/before-confirm.md
@@ -1,18 +1,19 @@
 ---
-title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
-order: 1
-desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+title: 上传前显示确认对话框。
+order: 2
+desc: 上传前和用户进行确认，可配置具体提示内容。
 ---
 
 ```jsx
 /**
- * title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
- * desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+ * title: 上传前显示确认对话框。
+ * desc: 上传前和用户进行确认，可配置具体提示内容。
  */
 import React from 'react';
 import { Message, Upload } from 'cloud-react';
 
 export default class UploadDemo extends React.Component {
+
   state = {
     fileList: []
   };
@@ -64,23 +65,19 @@ export default class UploadDemo extends React.Component {
       labelText: '点击上传',
       headers: {},
       action: '/upload',
+      showBeforeConfirm: true,
+      beforeConfirmBody: <span>确认需要上传吗？</span>,
+      beforeConfirmConfig: {
+        title: '确定要上传文件吗？',
+        body: '这里是上传后响应状态的描述'
+      },
       onProgress: this.handleProgress,
       onSuccess: this.handleSuccess,
       onRemove: this.handleRemove,
       onReUpload: this.handleReUpload
     };
 
-    const minorBtnProps = {
-      type: 'normal'
-    };
-
-    return (
-      <div>
-        <Upload {...props} fileList={this.state.fileList} />
-        <br />
-        <Upload {...props} fileList={this.state.fileList} btnOptions={minorBtnProps} />
-      </div>
-    );
+    return <Upload {...props} fileList={this.state.fileList} />;
   }
 }
 ```

--- a/src/components/upload/demos/before-upload.md
+++ b/src/components/upload/demos/before-upload.md
@@ -1,18 +1,19 @@
 ---
-title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
-order: 1
-desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+title: 选中文件之后，上传前执行，可以控制是否继续上传。
+order: 8
+desc: 通过返回的boolean值来决定是否继续上传。
 ---
 
 ```jsx
 /**
- * title: 经典款式，用户点击按钮弹出文件选择框，按钮样式可配置，主要使用主要按钮及次要按钮。
- * desc: 包含上传成功 onSuccess、删除已上传 onRemove、 重新上传 onReUpload。
+ * title: 选中文件之后，上传前执行，可以控制是否继续上传。
+ * desc: 通过返回的boolean值来决定是否继续上传。
  */
 import React from 'react';
 import { Message, Upload } from 'cloud-react';
 
 export default class UploadDemo extends React.Component {
+
   state = {
     fileList: []
   };
@@ -64,23 +65,17 @@ export default class UploadDemo extends React.Component {
       labelText: '点击上传',
       headers: {},
       action: '/upload',
+      onBeforeUpload: () => {
+        Message.error('操作失败');
+        return false;
+      },
       onProgress: this.handleProgress,
       onSuccess: this.handleSuccess,
       onRemove: this.handleRemove,
       onReUpload: this.handleReUpload
     };
 
-    const minorBtnProps = {
-      type: 'normal'
-    };
-
-    return (
-      <div>
-        <Upload {...props} fileList={this.state.fileList} />
-        <br />
-        <Upload {...props} fileList={this.state.fileList} btnOptions={minorBtnProps} />
-      </div>
-    );
+    return <Upload {...props} fileList={this.state.fileList} />;
   }
 }
 ```

--- a/src/components/upload/demos/custom-request.md
+++ b/src/components/upload/demos/custom-request.md
@@ -1,6 +1,6 @@
 ---
 title: 自定义上传。
-order: 2
+order: 3
 desc: 根据自身业务需求，传相应FormData。
 ---
 

--- a/src/components/upload/demos/custom-upload.md
+++ b/src/components/upload/demos/custom-upload.md
@@ -1,6 +1,6 @@
 ---
 title: 自定义上传显示
-order: 6
+order: 7
 desc: 自定义上传显示。
 ---
 

--- a/src/components/upload/demos/file-list-picture.md
+++ b/src/components/upload/demos/file-list-picture.md
@@ -1,6 +1,6 @@
 ---
 title: 图片形式已上传列表
-order: 5
+order: 6
 desc: 使用 fileList 设置已上传的图片列表进行控制。
 ---
 

--- a/src/components/upload/demos/file-list-text.md
+++ b/src/components/upload/demos/file-list-text.md
@@ -1,6 +1,6 @@
 ---
 title: 已上传的文件列表
-order: 4
+order: 5
 desc: 使用 fileList 设置已上传的文件列表。
 ---
 

--- a/src/components/upload/demos/picture.md
+++ b/src/components/upload/demos/picture.md
@@ -1,6 +1,6 @@
 ---
 title: 图片形式上传
-order: 3
+order: 4
 desc: 设置 type=picture 样式上传，并且处理上传失败 onError 的情况。
 ---
 

--- a/src/components/upload/index.js
+++ b/src/components/upload/index.js
@@ -73,7 +73,7 @@ class Upload extends Component {
   onClick = (e) => {
     const element = this.ref.current;
     if (!element || e?.target === element) return;
-    const { onClick, showBeforeConfirm, beforeConfirmBody } = this.props;
+    const { onClick, showBeforeConfirm, beforeConfirmBody, beforeConfirmConfig } = this.props;
 
     onClick().then(() => {
       if (!showBeforeConfirm) {
@@ -81,7 +81,9 @@ class Upload extends Component {
         return;
       }
       Modal.confirm({
+        icon: 'info_1',
         body: beforeConfirmBody,
+        ...beforeConfirmConfig,
         onOk: () => {
           element.click();
         },
@@ -222,8 +224,10 @@ class Upload extends Component {
   /**
    * 文件上传之前校验大小是否符合
    */
-  handleBeforeUpload(file) {
-    const { size, unit } = this.props;
+  async handleBeforeUpload(file) {
+    const {
+      size, unit, accept, onBeforeUpload,
+    } = this.props;
 
     let isSizeInvalidate;
 
@@ -241,23 +245,40 @@ class Upload extends Component {
       return false;
     }
 
-    if (this.props.onBeforeUpload) {
-      return this.props.onBeforeUpload(file);
+    if (accept !== '*') {
+      const fileNames = file.name.split('.') || [];
+      const fileType = `.${fileNames[fileNames.length - 1]}`;
+      if (!accept.includes(file.type) && !accept.includes(fileType)) {
+        Message.error(`仅支持上传${accept}格式的文件`);
+        this.ref.current.value = '';
+        return false;
+      }
+    }
+
+    if (onBeforeUpload) {
+      const _result = await onBeforeUpload(file);
+      return _result;
     }
 
     return true;
   }
 
-  upload(file) {
+  async upload(file) {
     const { unify } = this.props;
     if (unify) {
-      const sizeValidate = file.filter((item) => this.handleBeforeUpload(item));
-      if (file.length === sizeValidate.length) {
-        this.post(file);
-      }
+      const _errFile = [];
+      file.forEach(async (fileItem, index) => {
+        const before = await this.handleBeforeUpload(fileItem);
+        if (!before) {
+          _errFile.push(fileItem);
+        }
+        if (before && index + 1 === file.length && !_errFile.length) {
+          this.post(file);
+        }
+      });
     } else {
-      file.forEach((fileItem) => {
-        const before = this.handleBeforeUpload(fileItem);
+      file.forEach(async (fileItem) => {
+        const before = await this.handleBeforeUpload(fileItem);
         if (before) {
           this.post(fileItem);
         }
@@ -396,13 +417,14 @@ class Upload extends Component {
         />
         {isShowPreview && (
           <Modal
+            modalStyle={{ width: 680, height: 680 }}
             hasFooter={false}
             className={`${PREFIX}-pic-preview`}
             title={name}
             visible={isShowPreview}
             onClose={() => this.handlePreview()}
           >
-            <img src={url} alt="" />
+            <div className={`${PREFIX}-pic-preview-detail`} style={{ backgroundImage: `url(${url})` }} />
           </Modal>
         )}
         {this.renderUpload()}
@@ -444,7 +466,7 @@ Upload.propTypes = {
   type: PropTypes.oneOf([ TYPE.PICTURE, TYPE.DEFAULT ]),
   btnOptions: PropTypes.object,
   labelText: PropTypes.string,
-  accept: PropTypes.string,
+  accept: PropTypes.oneOfType([ PropTypes.array, PropTypes.string ]),
   size: PropTypes.number,
   unit: PropTypes.string,
   limit: PropTypes.number,
@@ -456,6 +478,7 @@ Upload.propTypes = {
   hasPreview: PropTypes.bool,
   showBeforeConfirm: PropTypes.bool,
   beforeConfirmBody: PropTypes.node,
+  beforeConfirmConfig: PropTypes.object,
   customRequest: PropTypes.func,
   onClick: PropTypes.func,
   onBeforeUpload: PropTypes.func,
@@ -486,6 +509,9 @@ Upload.defaultProps = {
   customRequest: undefined,
   showBeforeConfirm: false,
   beforeConfirmBody: '确认上传？',
+  beforeConfirmConfig: {
+    title: '确定要上传文件吗？',
+  },
   onClick: () => new Promise((resolve) => resolve()),
   onBeforeUpload: undefined,
   onProgress: noop,

--- a/src/components/upload/index.less
+++ b/src/components/upload/index.less
@@ -82,8 +82,11 @@
 	}
 
 	&-pic-preview {
-		img {
-			width: 100%;
+		&-detail {
+			height: 590px;
+			background-repeat: no-repeat;
+			background-size: contain;
+			background-position: center;
 		}
 	}
 
@@ -113,6 +116,7 @@
 
 		.@{upload-prefix-cls}-list-delete {
 			position: relative;
+			cursor: pointer;
 			background: @gray-4;
 			width: 14px;
 			height: 14px;
@@ -167,12 +171,13 @@
 				column-gap: 16px;
 
 				&-detail {
-					width: 28px;
-					height: 28px;
-					flex-basis: 28px;
+					width: 32px;
+					height: 32px;
+					flex-basis: 32px;
 
 					> img {
-						max-width: 28px;
+						max-width: 32px;
+						border-radius: 2px;
 					}
 				}
 			}
@@ -183,7 +188,7 @@
 		}
 
 		&-type-icon {
-			font-size: 28px;
+			font-size: 32px;
 		}
 
 		&-pic {
@@ -228,7 +233,7 @@
 				.@{upload-prefix-cls}-list-delete {
 					position: absolute;
 					top: -16px;
-					right: -13px;
+					right: -16px;
 				}
 			}
 

--- a/src/components/upload/index.md
+++ b/src/components/upload/index.md
@@ -34,7 +34,9 @@ group:
 | multiple          | 是否上传多个文件                                                | boolean     | false                        |
 | isShowIcon        | 是否显示上传按钮前面的图标                                      | boolean     | true                         |
 | showBeforeConfirm | 上传前是否显示确认对话框                                        | boolean     | false                        |
-| beforeConfirmBody | 上传前的确认对话框中的提示信息                                  | any         | '确认上传吗?'                |
+| beforeConfirmBody | 上传前的确认对话框中的提示描述，如只需配置提示描述可使用此参数         | any         | '确认上传吗?'                |
+| beforeConfirmConfig | 上传前的确认对话框的配置信息，相关配置信息可参考Modal.confirm     | any         | { title: '确定要上传文件吗？' }                |
+| unify             | 是否一次性上传多个文件                                                | boolean     | false                        |
 | onClick           | 返回Promise对像，当未执行resolve()时将中止上传  | func | () => new Promise(resolve => resolve())  |
 | onBeforeUpload    | 选中文件之后，上传前执行，通过返回的boolean值来决定是否继续上传   | func        |                              |
 | customRequest     | 自定义上传                                                      | func        |                              |
@@ -123,6 +125,10 @@ group:
  ### 代码演示 
 
 <embed src="@components/upload/demos/basic-upload.md" /> 
+
+<embed src="@components/upload/demos/before-confirm.md" /> 
+
+<embed src="@components/upload/demos/before-upload.md" /> 
 
 <embed src="@components/upload/demos/custom-request.md" /> 
 

--- a/src/components/upload/list.js
+++ b/src/components/upload/list.js
@@ -54,16 +54,14 @@ const TextItem = ({ item, disabled, onRemove }) => {
           )}
         </div>
         {!disabled && (
-          <div className={`${prefix}-text-actions`}>
-            <div className={`${prefix}-delete`}>
-              <Icon
-                type="close"
-                style={{ fontSize: '14px' }}
-                onClick={() => {
-                  onRemove(item);
-                }}
-              />
-            </div>
+          <div className={`${prefix}-delete`}>
+            <Icon
+              type="close"
+              style={{ fontSize: '14px' }}
+              onClick={() => {
+                onRemove(item);
+              }}
+            />
           </div>
         )}
       </div>
@@ -114,7 +112,7 @@ const Picture = (props) => {
           {hasPreview && (
             <Icon
               type="view"
-              style={{ fontSize: '17px', marginRight: disabled ? 0 : 18 }}
+              style={{ fontSize: '16px', marginRight: disabled ? 0 : 16 }}
               onClick={() => {
                 onPreview(item);
               }}
@@ -124,7 +122,7 @@ const Picture = (props) => {
             <>
               <Icon
                 type="edit"
-                style={{ fontSize: '14px' }}
+                style={{ fontSize: '16px' }}
                 onClick={() => {
                   onReUpload({ ...item, index });
                 }}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [ ] 组件样式改进


### 💡 需求背景和解决方案

1.ui优化
2.onBeforeUpload新增支持异步函数
3.组件内部支持判断可选文件类型

### 📝 更新日志怎么写？

1.onBeforeUpload新增支持异步函数
2.新增普通文件上传显示类型图标
3.组件内部支持判断可选文件类型
4.部分ui优化

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充
