### PR TITLE
fix: [CPicker] 区间单侧时间禁用时，选择另一侧后直接关闭面板

### DIFF
--- a/src/components/c-picker/demos/range-picker.md
+++ b/src/components/c-picker/demos/range-picker.md
@@ -99,19 +99,21 @@ class RangePickerDemo extends React.Component {
 					/>
 				</Form.Item>
 
-				<Form.Item label="日期范围选择器（带时间）">
+				<Form.Item label="日期范围选择器（带时间，固定开始日期）">
 					<RangePicker
 						value={values}
 						onChange={this.onChange}
 						showTimePicker
 						showToday
 						showNow
-						minDate={new Date()}
-						disabled={disabled}
+						minDate="2022/01/01 00:00:00"
+						defaultTime={['08:00:00', '23:00:00']}
+						disabled={[true, false]}
+						allowEmpty={[true, false]}
 					/>
 				</Form.Item>
 
-				<Form.Item label="日期范围选择器（固定开始时间）">
+				<Form.Item label="日期范围选择器（固定结束日期）">
 					<RangePicker
 						value={values}
 						onChange={this.onChange}

--- a/src/components/c-picker/pickers/date-range.js
+++ b/src/components/c-picker/pickers/date-range.js
@@ -11,6 +11,8 @@ import generatePicker from '../generator';
 import { dateFormat, dateTimeFormat, timeFormat, pickerDefaultFormatMap } from '../formats';
 import { STR, OBJ, transformString2Moment } from '../utils';
 
+const reversedRangeTypeIndexMap = { start: 1, end: 0 };
+
 const { DateRangePicker: Picker } = generatePicker(momentGenerateConfig);
 
 const DateRangePicker = ({
@@ -57,6 +59,7 @@ const DateRangePicker = ({
   presets,
   type = 'date',
 }) => {
+  const ref = useRef();
   const { current: _this } = useRef({
     formatType: STR,
   });
@@ -170,6 +173,18 @@ const DateRangePicker = ({
     [onPanelChange, format],
   );
 
+  const handleCalendarChange = useCallback(
+    (_, __, { range: val }) => {
+      // 特殊处理：区间单侧时间禁用时，选择另一侧后直接关闭面板
+      if (disabled instanceof Array && disabled[reversedRangeTypeIndexMap[val]]) {
+        setTimeout(() => {
+          ref.current?.blur();
+        }, 10);
+      }
+    },
+    [disabled],
+  );
+
   const handleChange = useCallback(
     (m, str) => {
       const val = m && m.map((x) => (handleGetDisabledDate(x) ? undefined : x));
@@ -223,6 +238,7 @@ const DateRangePicker = ({
 
   return (
     <Picker
+      ref={ref}
       size={size}
       style={{ width, ...style }}
       defaultValue={
@@ -240,6 +256,7 @@ const DateRangePicker = ({
             : false
       }
       onChange={handleChange}
+      onCalendarChange={handleCalendarChange}
       onOk={handleOk}
       onPanelChange={handlePanelChange}
       inputReadOnly={!canEdit}


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 README.md，当前是从 master 或者 v1-master 拉取的分支。
2、请自己 merge 代码到 develop 或者 v1-develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 或者 v1-master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [ ] bugfix
-   [ ] 组件库站点、文档改进
-   [x] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [x] 文档已补充或无须补充
-   [x] 代码演示已提供或无须提供
