### PR TITLE
[CTable]设置默认列添加二次确认弹窗；[Modal]添加新配置outerClassName和isReverseBtn；[Tooltip]新增control参数，结合visible使用，实现手动控制浮层显隐

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -9,6 +9,31 @@ group:
   order: 3
 ---
 
+# [2.1.0](https://github.com/ShuyunFF2E/cloud-react/compare/v2.0.2...v2.1.0) (2024-10-25)
+
+
+### Bug Fixes
+
+* [Tree] 解决搜索节点，若匹配到的节点有多级，应全部展示，实际上只展示了匹配到节点的下一级的问题 ([58ad498](https://github.com/ShuyunFF2E/cloud-react/commit/58ad498e5bd6cffee4c049b5294826bd11af0929))
+* 【级联选择器】1、升级rc-cascader版本，修复搜索结果异常问题 2、输入状态下，输入框预置的文字色值改为gray-6 ([9b837aa](https://github.com/ShuyunFF2E/cloud-react/commit/9b837aa))
+
+
+### Features
+
+* [CTable] 修改表格样式 ([0a3d685](https://github.com/ShuyunFF2E/cloud-react/commit/0a3d68523386380da86f4ae238ce248b9b465ae0))
+* [CTable] 删除测试代码 ([3ad94e8](https://github.com/ShuyunFF2E/cloud-react/commit/3ad94e82cbafb86f00c267a8e572ef448fcc48f0))
+* [CTable] 表格配置列添加参数：defaultConfigColumns 和 disabledSortColumns ([6c3eb12](https://github.com/ShuyunFF2E/cloud-react/commit/6c3eb123d5183170851d27d1097682d09259171a))
+* 修改依赖包 ([61cea7a](https://github.com/ShuyunFF2E/cloud-react/commit/61cea7a062bc2baa7fc49f80bc27c40d5dc3d45c))
+* 修改依赖包 ([a8d08cb](https://github.com/ShuyunFF2E/cloud-react/commit/a8d08cb4012e0e01d40a2bd195cadabbeaa68191))
+* 添加代码提交前校验 ([850cc7a](https://github.com/ShuyunFF2E/cloud-react/commit/850cc7ae8596269d2e95e61283195381d40324bf))
+* 添加代码提交前校验，便于生成日志 ([5edc635](https://github.com/ShuyunFF2E/cloud-react/commit/5edc6350a5dec986c80ec9cbf33ddd541976bbdb))
+* 表格支持配置列的展示和隐藏（复杂模式，支持拖拽和重置） ([675dff7](https://github.com/ShuyunFF2E/cloud-react/commit/675dff70355af669225bf8119108807b5f6705e0))
+* 表格支持配置列的展示和隐藏（复杂模式，支持拖拽和重置） ([ec35eb2](https://github.com/ShuyunFF2E/cloud-react/commit/ec35eb23741d5ab8922a5be183f48f25c03679e8))
+* [tooltip]设置滚动根节点 ([a5cf0a6](https://github.com/ShuyunFF2E/cloud-react/commit/a5cf0a6))
+
+
+
+
 ### Changelog
 
 ### [v2.0.2](https://github.com/ShuyunFF2E/cloud-react/compare/v1.0.33...v2.0.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloud-react",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "数据赢家 react 组件",
   "scripts": {
     "gen:index": "node ./scripts/generate-index.js",

--- a/src/components/c-table/js/columnConfig.js
+++ b/src/components/c-table/js/columnConfig.js
@@ -174,6 +174,7 @@ class ColumnConfig extends Component {
                 title: '确定恢复为系统默认设置吗？',
                 body: '确定后，已编辑内容将不会被保存',
                 outerClassName: `${tablePrefixCls}-modal-outer`,
+                isReverseBtn: true,
                 onOk: () => {
                   if (!defaultConfigColumns?.length) {
                     setOriginColumnData(originConfigColumnData.map(item => ({

--- a/src/components/c-table/js/columnConfig.js
+++ b/src/components/c-table/js/columnConfig.js
@@ -6,6 +6,7 @@ import Icon from '../../icon';
 import Popover from '../../popover';
 import Checkbox from '../../checkbox';
 import Button from '../../button';
+import Modal from '../../modal';
 // import { setConfig } from '../util';
 
 const columnConfigPanelHeight = 466;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,7 +17,7 @@ bodys.style.setProperty(`--shuyunBlue${i + 1}`,color)
 }
 }
 
-export const version = '2.0.2';
+export const version = '2.1.0';
 
 export { default as Avatar } from './avatar';
 

--- a/src/components/modal/demos/basic-modal.md
+++ b/src/components/modal/demos/basic-modal.md
@@ -83,6 +83,7 @@ class ModalDemo extends React.Component {
 					size="medium"
 					visible={this.state.visible}
 					showMask={this.state.showMask}
+					isReverseBtn={true}
 					clickMaskCanClose={this.state.clickMaskCanClose}
 					onOk={this.handleOk}
 					onCancel={this.handleCancel}

--- a/src/components/modal/demos/confirm.md
+++ b/src/components/modal/demos/confirm.md
@@ -35,6 +35,7 @@ class ModalDemo extends React.Component {
 			title: '基本确认对话框',
 			body: '杭州数云信息技术有限公司是国内领先的全域消费者增长方案提供商',
 			cancelBtnOpts: { type: 'secondary' },
+			isReverseBtn: true,
 			// hasFooter: false,
       //       className: "test",
 			onOk: () => {

--- a/src/components/modal/index.less
+++ b/src/components/modal/index.less
@@ -21,6 +21,7 @@
 
 @confirm-loading-border: 1px solid #ddd;
 @confirm-loading-border-top: 1px solid @color-white;
+
 .@{modal-prefix-cls} {
   position: fixed;
   top: 0;
@@ -28,6 +29,7 @@
   bottom: 0;
   left: 0;
   z-index: @z-index-modal-mask;
+
   &-mask {
     position: fixed;
     top: 0;
@@ -75,16 +77,19 @@
     opacity: 0;
     transform: scale(0.5);
   }
+
   &-enter-active,
   &-appear-active {
     opacity: 1;
     transform: scale(1);
     transition: opacity 300ms, transform 300ms;
   }
+
   &-exit {
     opacity: 1;
     transform: scale(1);
   }
+
   &-exit-active {
     opacity: 0;
     transform: scale(0.5);
@@ -145,20 +150,24 @@
       width: 8px;
       height: 8px;
     }
+
     &::-webkit-scrollbar-thumb {
       /*滚动条里面小方块*/
       background: @scrollbar-thumb;
       border-radius: @body-border-radius;
+
       &:hover {
         background: @gray-7;
       }
     }
+
     &::-webkit-scrollbar-track {
       /*滚动条里面轨道*/
       width: 8px;
       border-radius: 0;
       // background: @scrollbar-bg;
     }
+
     &::-webkit-scrollbar-corner {
       /*右下角按钮样式*/
       background: @scrollbar-bg;
@@ -191,6 +200,13 @@
       justify-content: flex-end;
     }
 
+    &-reverse {
+      display: flex;
+      justify-content: right;
+      flex-direction: row-reverse;
+      gap: 16px;
+    }
+
     .@{modal-prefix-cls}-confirm-btn {
       margin-left: 16px;
     }
@@ -220,6 +236,7 @@
       border-radius: @body-border-small-radius;
     }
   }
+
   &&-middle {
     .@{modal-prefix-cls}-header {
       border-radius: @body-border-middle-radius @body-border-middle-radius 0 0;
@@ -280,7 +297,7 @@
     line-height: 24px;
     vertical-align: text-top;
     margin-right: 8px;
-    padding: 0!important;
+    padding: 0 !important;
   }
 
   .confirm-style {

--- a/src/components/modal/index.md
+++ b/src/components/modal/index.md
@@ -26,6 +26,8 @@ group:
 | footerStyle        | 设置弹出框footer区域样式                 | object              | -       |
 | disabledOk         | 禁用确认按钮                             | boolean             | `false` |
 | className          | 设置弹出框样式名称                       | string              | -       |
+| outerClassName     | 设置最外层mark样式                       | string              | -       |
+| isReverseBtn       | 是否反转确定和取消的位置                   | boolean             | `false`  |
 | hasFooter          | 是否显示底部区域                         | boolean             | `true`  |
 | footer             | modal 底部内容区域                       | string 或 ReactNode | -       |
 | onClose            | 点击右上角关闭按钮时触发的回调           | function            | -       |

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -70,6 +70,7 @@ class Notification extends Component {
     onClose: noop,
     supportDrag: true,
     borderRadiusSize: 'large',
+    isReverseBtn: false,
   };
 
   static propTypes = {
@@ -88,6 +89,7 @@ class Notification extends Component {
     okBtnOpts: PropTypes.object,
     cancelBtnOpts: PropTypes.object,
     hasFooter: PropTypes.bool,
+    isReverseBtn: PropTypes.bool,
     onOk: PropTypes.func,
     onCancel: PropTypes.func,
     onClose: PropTypes.func,
@@ -308,6 +310,7 @@ class Notification extends Component {
     });
   };
 
+
   render() {
     const {
       visible,
@@ -318,6 +321,8 @@ class Notification extends Component {
       headerStyle,
       disabledOk,
       className,
+      outerClassName,
+      isReverseBtn,
       type,
       children,
       title,
@@ -360,7 +365,7 @@ class Notification extends Component {
         <div
           id="mask"
           ref={this.maskRef}
-          className={classnames(`${prefixCls}-modal`, {
+          className={classnames(`${prefixCls}-modal`, outerClassName, {
             'other-area-can-click': !showMask,
             [`${prefixCls}-modal-${borderRadiusSize}`]: borderRadiusSize,
           })}
@@ -428,6 +433,7 @@ class Notification extends Component {
                 disabledOk={disabledOk}
                 showConfirmLoading={showConfirmLoading}
                 infoText={infoText}
+                isReverseBtn={isReverseBtn}
               />
             </div>
           </CSSTransition>
@@ -517,6 +523,7 @@ function ModalFooter({
   cancelBtnOpts,
   hasFooter,
   showConfirmLoading,
+  isReverseBtn,
   onCancel,
   onOk,
   onReset,
@@ -532,9 +539,11 @@ function ModalFooter({
     onReset();
     onCancel();
   };
+
   const footerClass = classnames(`${prefixCls}-modal-footer`, {
     [`${prefixCls}-modal-border`]: type !== 'modal',
     [`${prefixCls}-modal-footer-default`]: !(hasFooter && footer),
+    [`${prefixCls}-modal-footer-reverse`]: isReverseBtn,
   });
   const confirmClass = classnames(`${prefixCls}-modal-confirm-btn`);
   if (!hasFooter) {

--- a/src/components/modal/prompt.js
+++ b/src/components/modal/prompt.js
@@ -25,6 +25,8 @@ class Prompt extends React.Component {
     onOk: noop,
     onCancel: noop,
     hasFooter: true,
+    outerClassName: '',
+    isReverseBtn: false,
     className: '',
   };
 
@@ -41,6 +43,8 @@ class Prompt extends React.Component {
     onCancel: PropTypes.func,
     hasFooter: PropTypes.bool,
     className: PropTypes.string,
+    outerClassName: PropTypes.string,
+    isReverseBtn: PropTypes.bool,
   };
 
   constructor(props) {
@@ -189,6 +193,8 @@ class Prompt extends React.Component {
           showConfirmLoading={this.state.showConfirmLoading}
           hasFooter={this.props.hasFooter}
           className={this.props.className}
+          outerClassName={this.props.outerClassName}
+          isReverseBtn={this.props.isReverseBtn}
           infoText={infoText}
         >
           <div>
@@ -243,6 +249,8 @@ function prompt({
   title,
   hasFooter,
   className,
+  outerClassName,
+  isReverseBtn,
   infoText,
 }) {
   // 创建一个关联id
@@ -264,6 +272,8 @@ function prompt({
       iconStyle={iconStyle}
       isShowIcon={isShowIcon}
       hasFooter={hasFooter}
+      outerClassName={outerClassName}
+      isReverseBtn={isReverseBtn}
       className={className}
       okText={okText}
       cancelText={cancelText}


### PR DESCRIPTION
<!--
首先，非常感谢你的贡献！😄

1、确保您已经读了 README.md，当前是从 master 或者 v1-master 拉取的分支。
2、请自己 merge 代码到 develop 或者 v1-develop 分支，通知维护者发布测试版本。
3、测试通过，请提交 pr 至 master 或者 v1-master 分支，在维护者审核通过后合并，发布正式版本。
4、测试不通过，在自己分支继续就行修复，重复2的过程。
请确保填写以下 pull request 的信息，谢谢！~

-->

### 🤔 这个变动的性质是？

-   [ ] 新功能提交
-   [ ] bugfix
-   [ ] 组件库站点、文档改进
-   [ ] 组件样式改进
-   [ ] 代码风格优化
-   [ ] 重构
-   [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- 请在pr创建完成，右侧 linked issue 链接您的issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志怎么写？

<!--
> 从用户角度描述具体变化，以及可能的 breaking change 和其他风险？
-->

### ☑️ 请求合并前的自查清单

-   [ ] 文档已补充或无须补充
-   [ ] 代码演示已提供或无须提供
